### PR TITLE
fix: unneeded state reloading

### DIFF
--- a/sources/zafira-web/angular/client/app/components/blocks/app-header/app-header.controller.js
+++ b/sources/zafira-web/angular/client/app/components/blocks/app-header/app-header.controller.js
@@ -38,6 +38,7 @@ const appHeaderController = function(UserService, $rootScope, ConfigService, pro
                 const projects = projectsService.getSelectedProjects();
 
                 if (!angular.equals(projects, vm.selectedProjects)) {
+                    if (!projects && !vm.selectedProjects) { return; }
                     if (vm.selectedProjects && vm.selectedProjects.length) {
                         projectsService.setSelectedProjects(vm.selectedProjects);
                     } else {


### PR DESCRIPTION
Fix: page reloading after projects menu opened and then closed and nothing was selected/changed