### PR TITLE
Controllers refactoring

### DIFF
--- a/sources/zafira-ws/src/main/java/com/qaprosoft/zafira/ws/controller/application/CertificationAPIController.java
+++ b/sources/zafira-ws/src/main/java/com/qaprosoft/zafira/ws/controller/application/CertificationAPIController.java
@@ -15,36 +15,32 @@
  *******************************************************************************/
 package com.qaprosoft.zafira.ws.controller.application;
 
+import com.qaprosoft.zafira.models.dto.CertificationType;
+import com.qaprosoft.zafira.services.exceptions.ServiceException;
 import com.qaprosoft.zafira.services.services.application.CertificationService;
 import com.qaprosoft.zafira.ws.controller.AbstractController;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.ResponseBody;
-import org.springframework.web.bind.annotation.ResponseStatus;
-
-import com.qaprosoft.zafira.models.dto.CertificationType;
-import com.qaprosoft.zafira.services.exceptions.ServiceException;
-
+import org.springframework.web.bind.annotation.RestController;
 import springfox.documentation.annotations.ApiIgnore;
 
-@Controller
 @ApiIgnore
-@RequestMapping("api/certification")
-public class CertificationAPIController extends AbstractController
-{
+@RequestMapping(path = "api/certification", produces = MediaType.APPLICATION_JSON_VALUE)
+@RestController
+public class CertificationAPIController extends AbstractController {
 
-	@Autowired
-	private CertificationService certificationService;
+    @Autowired
+    private CertificationService certificationService;
 
-	@ResponseStatus(HttpStatus.OK)
-	@RequestMapping(path="details", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-	public @ResponseBody CertificationType getCertifcationDetails(@RequestParam(value="upstreamJobId") Long upstreamJobId, @RequestParam(value="upstreamJobBuildNumber") Integer upstreamJobBuildNumber) throws ServiceException
-	{
-		return certificationService.getCertificationDetails(upstreamJobId, upstreamJobBuildNumber);
-	}
+    @GetMapping("/details")
+    public CertificationType getCertifcationDetails(
+            @RequestParam("upstreamJobId") Long upstreamJobId,
+            @RequestParam("upstreamJobBuildNumber") Integer upstreamJobBuildNumber
+    ) throws ServiceException {
+        return certificationService.getCertificationDetails(upstreamJobId, upstreamJobBuildNumber);
+    }
+
 }

--- a/sources/zafira-ws/src/main/java/com/qaprosoft/zafira/ws/controller/application/ConfigurationAPIController.java
+++ b/sources/zafira-ws/src/main/java/com/qaprosoft/zafira/ws/controller/application/ConfigurationAPIController.java
@@ -15,22 +15,6 @@
  *******************************************************************************/
 package com.qaprosoft.zafira.ws.controller.application;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import org.apache.commons.lang.StringUtils;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
-import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.CrossOrigin;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.ResponseBody;
-import org.springframework.web.bind.annotation.ResponseStatus;
-
 import com.qaprosoft.zafira.models.db.Project;
 import com.qaprosoft.zafira.models.db.TestRun;
 import com.qaprosoft.zafira.services.exceptions.ServiceException;
@@ -42,16 +26,27 @@ import com.qaprosoft.zafira.services.services.application.integration.impl.JiraS
 import com.qaprosoft.zafira.services.services.application.integration.impl.SlackService;
 import com.qaprosoft.zafira.ws.controller.AbstractController;
 import com.qaprosoft.zafira.ws.swagger.annotations.ResponseStatusDetails;
-
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiImplicitParam;
 import io.swagger.annotations.ApiImplicitParams;
 import io.swagger.annotations.ApiOperation;
+import org.apache.commons.lang.StringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
-@Controller
-@Api(value = "Configuration API")
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Api("Configuration API")
 @CrossOrigin
-@RequestMapping("api/config")
+@RequestMapping(path = "api/config", produces = MediaType.APPLICATION_JSON_VALUE)
+@RestController
 public class ConfigurationAPIController extends AbstractController {
 
     @Autowired
@@ -74,11 +69,9 @@ public class ConfigurationAPIController extends AbstractController {
 
     @ResponseStatusDetails
     @ApiOperation(value = "Get version", nickname = "getVersion", httpMethod = "GET", response = Map.class)
-    @ResponseStatus(HttpStatus.OK)
-    @ApiImplicitParams({ @ApiImplicitParam(name = "Authorization", paramType = "header") })
-    @RequestMapping(value = "version", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-    public @ResponseBody Map<String, Object> getVersion() throws ServiceException
-    {
+    @ApiImplicitParams({@ApiImplicitParam(name = "Authorization", paramType = "header")})
+    @GetMapping("/version")
+    public Map<String, Object> getVersion() throws ServiceException {
         Map<String, Object> config = new HashMap<>();
         config.put("service", versionService.getServiceVersion());
         config.put("client", versionService.getClientVersion());
@@ -87,22 +80,17 @@ public class ConfigurationAPIController extends AbstractController {
 
     @ResponseStatusDetails
     @ApiOperation(value = "Get all projects", nickname = "getAllProjects", httpMethod = "GET", response = List.class)
-    @ResponseStatus(HttpStatus.OK)
-    @ApiImplicitParams({ @ApiImplicitParam(name = "Authorization", paramType = "header") })
-    @RequestMapping(value = "projects", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-    public @ResponseBody
-    List<Project> getAllProjects() throws ServiceException
-    {
+    @ApiImplicitParams({@ApiImplicitParam(name = "Authorization", paramType = "header")})
+    @GetMapping("/projects")
+    public List<Project> getAllProjects() throws ServiceException {
         return projectService.getAllProjects();
     }
 
     @ResponseStatusDetails
     @ApiOperation(value = "Get jenkins config", nickname = "getJenkinsConfig", httpMethod = "GET", response = Map.class)
-    @ResponseStatus(HttpStatus.OK)
-    @ApiImplicitParams({ @ApiImplicitParam(name = "Authorization", paramType = "header") })
-    @RequestMapping(value = "jenkins", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-    public @ResponseBody Map<String, Object> getJenkinsConfig() throws ServiceException
-    {
+    @ApiImplicitParams({@ApiImplicitParam(name = "Authorization", paramType = "header")})
+    @GetMapping("/jenkins")
+    public Map<String, Object> getJenkinsConfig() throws ServiceException {
         Map<String, Object> config = new HashMap<>();
         config.put("connected", jenkinsService.isEnabledAndConnected());
         return config;
@@ -110,11 +98,9 @@ public class ConfigurationAPIController extends AbstractController {
 
     @ResponseStatusDetails
     @ApiOperation(value = "Get jira config", nickname = "getJiraConfig", httpMethod = "GET", response = Map.class)
-    @ResponseStatus(HttpStatus.OK)
-    @ApiImplicitParams({ @ApiImplicitParam(name = "Authorization", paramType = "header") })
-    @RequestMapping(value = "jira", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-    public @ResponseBody Map<String, Object> getJiraConfig() throws ServiceException
-    {
+    @ApiImplicitParams({@ApiImplicitParam(name = "Authorization", paramType = "header")})
+    @GetMapping("/jira")
+    public Map<String, Object> getJiraConfig() throws ServiceException {
         Map<String, Object> config = new HashMap<>();
         config.put("connected", jiraService.isEnabledAndConnected());
         return config;
@@ -122,40 +108,25 @@ public class ConfigurationAPIController extends AbstractController {
 
     @ResponseStatusDetails
     @ApiOperation(value = "Is slack available for test run", nickname = "isSlackAvailableForRun", httpMethod = "GET", response = Map.class)
-    @ResponseStatus(HttpStatus.OK)
-    @ApiImplicitParams({ @ApiImplicitParam(name = "Authorization", paramType = "header") })
-    @RequestMapping(value = "slack/{id}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-    public @ResponseBody Map<String, Object> isSlackAvailable(@PathVariable(value = "id") long id) throws ServiceException
-    {
+    @ApiImplicitParams({@ApiImplicitParam(name = "Authorization", paramType = "header")})
+    @GetMapping("/slack/{id}")
+    public Map<String, Object> isSlackAvailable(@PathVariable("id") long id) throws ServiceException {
         Map<String, Object> config = new HashMap<>();
         TestRun tr = testRunService.getTestRunByIdFull(id);
-        if (slackService.getWebhook() != null && StringUtils.isNotEmpty(tr.getSlackChannels()) && slackService.isEnabledAndConnected())
-        {
-            config.put("available", true);
-        }
-        else
-        {
-            config.put("available", false);
-        }
+        boolean available = slackService.getWebhook() != null && StringUtils.isNotEmpty(tr.getSlackChannels()) && slackService.isEnabledAndConnected();
+        config.put("available", available);
         return config;
     }
-    
+
     @ResponseStatusDetails
     @ApiOperation(value = "Is slack available", nickname = "isSlackAvailable", httpMethod = "GET", response = Map.class)
-    @ResponseStatus(HttpStatus.OK)
-    @ApiImplicitParams({ @ApiImplicitParam(name = "Authorization", paramType = "header") })
-    @RequestMapping(value = "slack", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-    public @ResponseBody Map<String, Object> isSlackAvailable() throws ServiceException
-    {
+    @ApiImplicitParams({@ApiImplicitParam(name = "Authorization", paramType = "header")})
+    @GetMapping("/slack")
+    public Map<String, Object> isSlackAvailable() throws ServiceException {
         Map<String, Object> config = new HashMap<>();
-        if (slackService.getWebhook() != null && slackService.isEnabledAndConnected())
-        {
-            config.put("available", true);
-        }
-        else
-        {
-            config.put("available", false);
-        }
+        boolean available = slackService.getWebhook() != null && slackService.isEnabledAndConnected();
+        config.put("available", available);
         return config;
     }
+
 }

--- a/sources/zafira-ws/src/main/java/com/qaprosoft/zafira/ws/controller/application/DashboardsAPIController.java
+++ b/sources/zafira-ws/src/main/java/com/qaprosoft/zafira/ws/controller/application/DashboardsAPIController.java
@@ -15,199 +15,183 @@
  *******************************************************************************/
 package com.qaprosoft.zafira.ws.controller.application;
 
-import java.util.List;
-import java.util.stream.Collectors;
-
-import javax.validation.Valid;
-
-import com.qaprosoft.zafira.models.dto.DashboardType;
-import com.qaprosoft.zafira.services.services.application.WidgetTemplateService;
-import com.qaprosoft.zafira.ws.controller.AbstractController;
-import org.dozer.Mapper;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
-import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.*;
-
 import com.qaprosoft.zafira.models.db.Attribute;
 import com.qaprosoft.zafira.models.db.Dashboard;
 import com.qaprosoft.zafira.models.db.Permission;
 import com.qaprosoft.zafira.models.db.Widget;
+import com.qaprosoft.zafira.models.dto.DashboardType;
 import com.qaprosoft.zafira.services.exceptions.ServiceException;
 import com.qaprosoft.zafira.services.services.application.DashboardService;
+import com.qaprosoft.zafira.services.services.application.WidgetTemplateService;
+import com.qaprosoft.zafira.ws.controller.AbstractController;
 import com.qaprosoft.zafira.ws.swagger.annotations.ResponseStatusDetails;
-
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiImplicitParam;
 import io.swagger.annotations.ApiImplicitParams;
 import io.swagger.annotations.ApiOperation;
+import org.dozer.Mapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
-@Controller
-@Api(value = "Dashboards API")
+import javax.validation.Valid;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Api("Dashboards API")
 @CrossOrigin
-@RequestMapping("api/dashboards")
-public class DashboardsAPIController extends AbstractController
-{
+@RequestMapping(path = "api/dashboards", produces = MediaType.APPLICATION_JSON_VALUE)
+@RestController
+public class DashboardsAPIController extends AbstractController {
 
-	@Autowired
-	private DashboardService dashboardService;
+    @Autowired
+    private DashboardService dashboardService;
 
-	@Autowired
-	private WidgetTemplateService widgetTemplateService;
+    @Autowired
+    private WidgetTemplateService widgetTemplateService;
 
-	@Autowired
-	private Mapper mapper;
+    @Autowired
+    private Mapper mapper;
 
     @ResponseStatusDetails
     @ApiOperation(value = "Create dashboard", nickname = "createDashboard", httpMethod = "POST", response = Dashboard.class)
-	@ResponseStatus(HttpStatus.OK) @ApiImplicitParams({ @ApiImplicitParam(name = "Authorization", paramType = "header") })
-	@PreAuthorize("hasPermission('MODIFY_DASHBOARDS')")
-	@RequestMapping(method = RequestMethod.POST, produces = MediaType.APPLICATION_JSON_VALUE)
-	public @ResponseBody DashboardType createDashboard(@RequestBody @Valid DashboardType dashboard) throws ServiceException
-	{
-		return mapper.map(dashboardService.createDashboard(mapper.map(dashboard, Dashboard.class)), DashboardType.class);
-	}
+    @ApiImplicitParams({@ApiImplicitParam(name = "Authorization", paramType = "header")})
+    @PreAuthorize("hasPermission('MODIFY_DASHBOARDS')")
+    @PostMapping
+    public DashboardType createDashboard(@RequestBody @Valid DashboardType dashboard) throws ServiceException {
+        return mapper.map(dashboardService.createDashboard(mapper.map(dashboard, Dashboard.class)), DashboardType.class);
+    }
 
     @ResponseStatusDetails
     @ApiOperation(value = "Get dashboards", nickname = "getAllDashboards", httpMethod = "GET", response = List.class)
-	@ResponseStatus(HttpStatus.OK) @ApiImplicitParams({ @ApiImplicitParam(name = "Authorization", paramType = "header") })
-	@RequestMapping(method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-	public @ResponseBody List<DashboardType> getAllDashboards(@RequestParam(value="hidden", required=false) boolean hidden) throws ServiceException
-	{
-		List<Dashboard> dashboards;
-		if(!hidden && hasPermission(Permission.Name.VIEW_HIDDEN_DASHBOARDS))
-		{
-			dashboards = (dashboardService.getAllDashboards());
-		}
-		else
-		{
-			dashboards = dashboardService.getDashboardsByHidden(false);
-		}
+    @ApiImplicitParams({@ApiImplicitParam(name = "Authorization", paramType = "header")})
+    @GetMapping
+    public List<DashboardType> getAllDashboards(@RequestParam(value = "hidden", required = false) boolean hidden) throws ServiceException {
+        List<Dashboard> dashboards;
+        if (!hidden && hasPermission(Permission.Name.VIEW_HIDDEN_DASHBOARDS)) {
+            dashboards = (dashboardService.getAllDashboards());
+        } else {
+            dashboards = dashboardService.getDashboardsByHidden(false);
+        }
 
-		return dashboards.stream().map(dashboard -> mapper.map(dashboard, DashboardType.class)).collect(Collectors.toList());
-	}
+        return dashboards.stream()
+                         .map(dashboard -> mapper.map(dashboard, DashboardType.class))
+                         .collect(Collectors.toList());
+    }
 
     @ResponseStatusDetails
     @ApiOperation(value = "Get dashboard by ID", nickname = "getDashboardById", httpMethod = "GET", response = Dashboard.class)
-	@ResponseStatus(HttpStatus.OK) @ApiImplicitParams({ @ApiImplicitParam(name = "Authorization", paramType = "header") })
-	@RequestMapping(value="{id}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-	public @ResponseBody DashboardType getDashboardById(@PathVariable(value="id") long id) throws ServiceException
-	{
-		Dashboard dashboard = dashboardService.getDashboardById(id);
-		dashboard.getWidgets().forEach(widget -> {
-			widgetTemplateService.clearRedundantParamsValues(widget.getWidgetTemplate());
-			//widgetTemplateService.executeWidgetTemplateParamsSQLQueries(widget.getWidgetTemplate());
-		});
-		return mapper.map(dashboard, DashboardType.class);
-	}
+    @ApiImplicitParams({@ApiImplicitParam(name = "Authorization", paramType = "header")})
+    @GetMapping("/{id}")
+    public DashboardType getDashboardById(@PathVariable("id") long id) throws ServiceException {
+        Dashboard dashboard = dashboardService.getDashboardById(id);
+        dashboard.getWidgets().forEach(widget -> widgetTemplateService.clearRedundantParamsValues(widget.getWidgetTemplate()));
+        return mapper.map(dashboard, DashboardType.class);
+    }
 
-	@ResponseStatusDetails
-	@ApiOperation(value = "Get dashboard by title", nickname = "getDashboardByTitle", httpMethod = "GET", response = Dashboard.class)
-	@ResponseStatus(HttpStatus.OK) @ApiImplicitParams({ @ApiImplicitParam(name = "Authorization", paramType = "header") })
-	@RequestMapping(value="title", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-	public @ResponseBody DashboardType getDashboardByTitle(@RequestParam(value="title", required=false) String title) throws ServiceException
-	{
-		return mapper.map(dashboardService.getDashboardByTitle(title), DashboardType.class);
-	}
+    @ResponseStatusDetails
+    @ApiOperation(value = "Get dashboard by title", nickname = "getDashboardByTitle", httpMethod = "GET", response = Dashboard.class)
+    @ApiImplicitParams({@ApiImplicitParam(name = "Authorization", paramType = "header")})
+    @GetMapping("/title")
+    public DashboardType getDashboardByTitle(@RequestParam(name = "title", required = false) String title) throws ServiceException {
+        return mapper.map(dashboardService.getDashboardByTitle(title), DashboardType.class);
+    }
 
     @ResponseStatusDetails
     @ApiOperation(value = "Delete dashboard", nickname = "deleteDashboard", httpMethod = "DELETE")
-	@ResponseStatus(HttpStatus.OK) @ApiImplicitParams({ @ApiImplicitParam(name = "Authorization", paramType = "header") })
-	@PreAuthorize("hasPermission('MODIFY_DASHBOARDS')")
-	@RequestMapping(value="{id}", method = RequestMethod.DELETE)
-	public void deleteDashboard(@PathVariable(value="id") long id) throws ServiceException
-	{
-		dashboardService.deleteDashboardById(id);
-	}
+    @ApiImplicitParams({@ApiImplicitParam(name = "Authorization", paramType = "header")})
+    @PreAuthorize("hasPermission('MODIFY_DASHBOARDS')")
+    @DeleteMapping("/{id}")
+    public void deleteDashboard(@PathVariable("id") long id) throws ServiceException {
+        dashboardService.deleteDashboardById(id);
+    }
 
     @ResponseStatusDetails
     @ApiOperation(value = "Update dashboard", nickname = "updateDashboard", httpMethod = "PUT", response = Dashboard.class)
-	@ResponseStatus(HttpStatus.OK) @ApiImplicitParams({ @ApiImplicitParam(name = "Authorization", paramType = "header") })
-	@PreAuthorize("hasPermission('MODIFY_DASHBOARDS')")
-	@RequestMapping(method = RequestMethod.PUT, produces = MediaType.APPLICATION_JSON_VALUE)
-	public @ResponseBody DashboardType updateDashboard(@Valid @RequestBody DashboardType dashboard) throws ServiceException
-	{
-		return mapper.map(dashboardService.updateDashboard(mapper.map(dashboard, Dashboard.class)), DashboardType.class);
-	}
+    @ApiImplicitParams({@ApiImplicitParam(name = "Authorization", paramType = "header")})
+    @PreAuthorize("hasPermission('MODIFY_DASHBOARDS')")
+    @PutMapping()
+    public DashboardType updateDashboard(@Valid @RequestBody DashboardType dashboard) throws ServiceException {
+        return mapper.map(dashboardService.updateDashboard(mapper.map(dashboard, Dashboard.class)), DashboardType.class);
+    }
 
     @ResponseStatusDetails
     @ApiOperation(value = "Add dashboard widget", nickname = "addDashboardWidget", httpMethod = "POST", response = Widget.class)
-	@ResponseStatus(HttpStatus.OK) @ApiImplicitParams({ @ApiImplicitParam(name = "Authorization", paramType = "header") })
-	@PreAuthorize("hasPermission('MODIFY_WIDGETS')")
-	@RequestMapping(value="{dashboardId}/widgets", method = RequestMethod.POST, produces = MediaType.APPLICATION_JSON_VALUE)
-	public @ResponseBody Widget addDashboardWidget(@PathVariable(value="dashboardId") long dashboardId, @RequestBody Widget widget) throws ServiceException
-	{
-		return dashboardService.addDashboardWidget(dashboardId, widget);
-	}
+    @ApiImplicitParams({@ApiImplicitParam(name = "Authorization", paramType = "header")})
+    @PreAuthorize("hasPermission('MODIFY_WIDGETS')")
+    @PostMapping("/{dashboardId}/widgets")
+    public Widget addDashboardWidget(@PathVariable("dashboardId") long dashboardId, @RequestBody Widget widget) throws ServiceException {
+        return dashboardService.addDashboardWidget(dashboardId, widget);
+    }
 
     @ResponseStatusDetails
     @ApiOperation(value = "Delete dashboard widget", nickname = "deleteDashboardWidget", httpMethod = "DELETE")
-	@ResponseStatus(HttpStatus.OK) @ApiImplicitParams({ @ApiImplicitParam(name = "Authorization", paramType = "header") })
-	@PreAuthorize("hasPermission('MODIFY_WIDGETS')")
-	@RequestMapping(value="{dashboardId}/widgets/{widgetId}", method = RequestMethod.DELETE)
-	public void deleteDashboardWidget(@PathVariable(value="dashboardId") long dashboardId, @PathVariable(value="widgetId") long widgetId) throws ServiceException
-	{
-		dashboardService.deleteDashboardWidget(dashboardId, widgetId);
-	}
+    @ApiImplicitParams({@ApiImplicitParam(name = "Authorization", paramType = "header")})
+    @PreAuthorize("hasPermission('MODIFY_WIDGETS')")
+    @DeleteMapping("/{dashboardId}/widgets/{widgetId}")
+    public void deleteDashboardWidget(@PathVariable("dashboardId") long dashboardId, @PathVariable("widgetId") long widgetId) throws ServiceException {
+        dashboardService.deleteDashboardWidget(dashboardId, widgetId);
+    }
 
     @ResponseStatusDetails
     @ApiOperation(value = "Update dashboard widget", nickname = "updateDashboardWidget", httpMethod = "PUT", response = Widget.class)
-	@ResponseStatus(HttpStatus.OK) @ApiImplicitParams({ @ApiImplicitParam(name = "Authorization", paramType = "header") })
-	@PreAuthorize("hasPermission('MODIFY_WIDGETS')")
-	@RequestMapping(value="{dashboardId}/widgets", method = RequestMethod.PUT, produces = MediaType.APPLICATION_JSON_VALUE)
-	public @ResponseBody Widget updateDashboardWidget(@PathVariable(value="dashboardId") long dashboardId, @RequestBody Widget widget) throws ServiceException
-	{
-		return dashboardService.updateDashboardWidget(dashboardId, widget);
-	}
+    @ApiImplicitParams({@ApiImplicitParam(name = "Authorization", paramType = "header")})
+    @PreAuthorize("hasPermission('MODIFY_WIDGETS')")
+    @PutMapping("/{dashboardId}/widgets")
+    public Widget updateDashboardWidget(@PathVariable("dashboardId") long dashboardId, @RequestBody Widget widget) throws ServiceException {
+        return dashboardService.updateDashboardWidget(dashboardId, widget);
+    }
 
-	@ResponseStatusDetails
-	@ApiOperation(value = "Update dashboard widget", nickname = "updateDashboardWidget", httpMethod = "PUT", response = Widget.class)
-	@ResponseStatus(HttpStatus.OK) @ApiImplicitParams({ @ApiImplicitParam(name = "Authorization", paramType = "header") })
-	@PreAuthorize("hasPermission('MODIFY_WIDGETS')")
-	@RequestMapping(value="{dashboardId}/widgets/all", method = RequestMethod.PUT, produces = MediaType.APPLICATION_JSON_VALUE)
-	public @ResponseBody List<Widget> updateDashboardWidgets(@PathVariable(value="dashboardId") long dashboardId, @RequestBody List<Widget> widgets) throws ServiceException
-	{
-		for(Widget widget : widgets)
-		{
-			dashboardService.updateDashboardWidget(dashboardId, widget);
-		}
-		return widgets;
-	}
+    @ResponseStatusDetails
+    @ApiOperation(value = "Update dashboard widget", nickname = "updateDashboardWidget", httpMethod = "PUT", response = Widget.class)
+    @ApiImplicitParams({@ApiImplicitParam(name = "Authorization", paramType = "header")})
+    @PreAuthorize("hasPermission('MODIFY_WIDGETS')")
+    @PutMapping("/{dashboardId}/widgets/all")
+    public List<Widget> updateDashboardWidgets(@PathVariable("dashboardId") long dashboardId, @RequestBody List<Widget> widgets) throws ServiceException {
+        for (Widget widget : widgets) {
+            dashboardService.updateDashboardWidget(dashboardId, widget);
+        }
+        return widgets;
+    }
 
-	@ResponseStatusDetails
+    @ResponseStatusDetails
     @ApiOperation(value = "Create dashboard attribute", nickname = "createDashboardAttribute", httpMethod = "POST", response = List.class)
-	@ResponseStatus(HttpStatus.OK) @ApiImplicitParams({ @ApiImplicitParam(name = "Authorization", paramType = "header") })
-	@PreAuthorize("hasPermission('MODIFY_DASHBOARDS')")
-	@RequestMapping(value="{dashboardId}/attributes", method = RequestMethod.POST, produces = MediaType.APPLICATION_JSON_VALUE)
-	public @ResponseBody List<Attribute> createDashboardAttribute(@PathVariable(value="dashboardId") long dashboardId, @RequestBody Attribute attribute)
-	{
-		dashboardService.createDashboardAttribute(dashboardId, attribute);
-		return dashboardService.getAttributesByDashboardId(dashboardId);
-	}
-	
-	@ResponseStatusDetails
+    @ApiImplicitParams({@ApiImplicitParam(name = "Authorization", paramType = "header")})
+    @PreAuthorize("hasPermission('MODIFY_DASHBOARDS')")
+    @PostMapping("/{dashboardId}/attributes")
+    public List<Attribute> createDashboardAttribute(@PathVariable("dashboardId") long dashboardId, @RequestBody Attribute attribute) {
+        dashboardService.createDashboardAttribute(dashboardId, attribute);
+        return dashboardService.getAttributesByDashboardId(dashboardId);
+    }
+
+    @ResponseStatusDetails
     @ApiOperation(value = "Update dashboard attribute", nickname = "createDashboardAttribute", httpMethod = "PUT", response = List.class)
-	@ResponseStatus(HttpStatus.OK) @ApiImplicitParams({ @ApiImplicitParam(name = "Authorization", paramType = "header") })
-	@PreAuthorize("hasPermission('MODIFY_DASHBOARDS')")
-	@RequestMapping(value="{dashboardId}/attributes", method = RequestMethod.PUT, produces = MediaType.APPLICATION_JSON_VALUE)
-	public @ResponseBody List<Attribute> updateDashboardAttribute(@PathVariable(value="dashboardId") long dashboardId, @RequestBody Attribute attribute)
-	{
-		dashboardService.updateAttribute(attribute);
-		return dashboardService.getAttributesByDashboardId(dashboardId);
-	}
-	
-	@ResponseStatusDetails
+    @ApiImplicitParams({@ApiImplicitParam(name = "Authorization", paramType = "header")})
+    @PreAuthorize("hasPermission('MODIFY_DASHBOARDS')")
+    @PutMapping("/{dashboardId}/attributes")
+    public List<Attribute> updateDashboardAttribute(@PathVariable("dashboardId") long dashboardId, @RequestBody Attribute attribute) {
+        dashboardService.updateAttribute(attribute);
+        return dashboardService.getAttributesByDashboardId(dashboardId);
+    }
+
+    @ResponseStatusDetails
     @ApiOperation(value = "Delete dashboard attribute", nickname = "createDashboardAttribute", httpMethod = "DELETE")
-	@ResponseStatus(HttpStatus.OK)
-	@ApiImplicitParams(
-	{ @ApiImplicitParam(name = "Authorization", paramType = "header") })
-	@PreAuthorize("hasPermission('MODIFY_DASHBOARDS')")
-	@RequestMapping(value="{dashboardId}/attributes/{id}", method = RequestMethod.DELETE, produces = MediaType.APPLICATION_JSON_VALUE)
-	public @ResponseBody List<Attribute> deleteDashboardAttribute(@PathVariable(value="dashboardId") long dashboardId, @PathVariable(value="id") long id)
-	{
-		dashboardService.deleteDashboardAttributeById(id);
-		return dashboardService.getAttributesByDashboardId(dashboardId);
-	}
+    @ApiImplicitParams({@ApiImplicitParam(name = "Authorization", paramType = "header")})
+    @PreAuthorize("hasPermission('MODIFY_DASHBOARDS')")
+    @DeleteMapping("/{dashboardId}/attributes/{id}")
+    public List<Attribute> deleteDashboardAttribute(@PathVariable("dashboardId") long dashboardId, @PathVariable("id") long id) {
+        dashboardService.deleteDashboardAttributeById(id);
+        return dashboardService.getAttributesByDashboardId(dashboardId);
+    }
+
 }

--- a/sources/zafira-ws/src/main/java/com/qaprosoft/zafira/ws/controller/application/DownloadAPIController.java
+++ b/sources/zafira-ws/src/main/java/com/qaprosoft/zafira/ws/controller/application/DownloadAPIController.java
@@ -7,10 +7,14 @@ import io.swagger.annotations.ApiImplicitParam;
 import io.swagger.annotations.ApiImplicitParams;
 import io.swagger.annotations.ApiOperation;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpStatus;
-import org.springframework.stereotype.Controller;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.util.FileCopyUtils;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServletResponse;
@@ -18,48 +22,37 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 
-@Api(value = "Download files API")
-@Controller
+@Api("Download files API")
 @CrossOrigin
 @RequestMapping("api/download")
-public class DownloadAPIController extends AbstractController
-{
+@RestController
+public class DownloadAPIController extends AbstractController {
 
-	private static final String DATA_FOLDER = "/opt/apk/%s";
+    private static final String DATA_FOLDER = "/opt/apk/%s";
 
-	@Autowired
-	private ServletContext context;
+    @Autowired
+    private ServletContext context;
 
-	@ResponseStatusDetails
-	@ResponseStatus(HttpStatus.OK)
-	@ApiImplicitParams(
-			{ @ApiImplicitParam(name = "Authorization", paramType = "header") })
-	@ApiOperation(value = "Download file by filename", nickname = "downloadFile", httpMethod = "GET")
-	@RequestMapping(method = RequestMethod.GET)
-	public void downloadFile(HttpServletResponse response, @RequestParam(value = "filename") String filename)
-			throws IOException
-	{
-		File file = new File(String.format(DATA_FOLDER, filename));
-		String mimeType = context.getMimeType(file.getPath());
-		if (mimeType == null)
-		{
-			mimeType = "application/octet-stream";
-		}
-		response.setContentType(mimeType);
-		response.setHeader("Content-Disposition", String.format("attachment; filename=\"%s\"", file.getName()));
-		response.setContentLength((int)file.length());
-		FileCopyUtils.copy(new FileInputStream(file), response.getOutputStream());
-		response.flushBuffer();
-	}
+    @ResponseStatusDetails
+    @ApiImplicitParams({@ApiImplicitParam(name = "Authorization", paramType = "header")})
+    @ApiOperation(value = "Download file by filename", nickname = "downloadFile", httpMethod = "GET")
+    @GetMapping()
+    public void downloadFile(HttpServletResponse response, @RequestParam("filename") String filename) throws IOException {
+        File file = new File(String.format(DATA_FOLDER, filename));
+        String mimeType = context.getMimeType(file.getPath());
+        response.setContentType(mimeType == null ? MediaType.APPLICATION_OCTET_STREAM_VALUE : mimeType);
+        response.setHeader(HttpHeaders.CONTENT_DISPOSITION, String.format("attachment; filename=\"%s\"", file.getName()));
+        response.setContentLength((int) file.length());
+        FileCopyUtils.copy(new FileInputStream(file), response.getOutputStream());
+        response.flushBuffer();
+    }
 
-	@ResponseStatusDetails
-	@ResponseStatus(HttpStatus.OK)
-	@ApiImplicitParams(
-			{ @ApiImplicitParam(name = "Authorization", paramType = "header") })
-	@ApiOperation(value = "Check file is present in file system", nickname = "checkFilePresence", httpMethod = "GET")
-	@RequestMapping(value = "check", method = RequestMethod.GET)
-	public @ResponseBody boolean checkFilePresence(@RequestParam(value = "filename") String filename)
-	{
-		return new File(String.format(DATA_FOLDER, filename)).exists();
-	}
+    @ResponseStatusDetails
+    @ApiImplicitParams({@ApiImplicitParam(name = "Authorization", paramType = "header")})
+    @ApiOperation(value = "Check file is present in file system", nickname = "checkFilePresence", httpMethod = "GET")
+    @GetMapping("/check")
+    public boolean checkFilePresence(@RequestParam("filename") String filename) {
+        return new File(String.format(DATA_FOLDER, filename)).exists();
+    }
+
 }

--- a/sources/zafira-ws/src/main/java/com/qaprosoft/zafira/ws/controller/application/FiltersAPIController.java
+++ b/sources/zafira-ws/src/main/java/com/qaprosoft/zafira/ws/controller/application/FiltersAPIController.java
@@ -1,115 +1,98 @@
 package com.qaprosoft.zafira.ws.controller.application;
 
-import java.util.List;
-import java.util.stream.Collectors;
-
-import javax.validation.Valid;
-
-import com.qaprosoft.zafira.ws.controller.AbstractController;
-import org.dozer.Mapper;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
-import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.CrossOrigin;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.ResponseBody;
-import org.springframework.web.bind.annotation.ResponseStatus;
-
 import com.qaprosoft.zafira.models.db.Filter;
 import com.qaprosoft.zafira.models.dto.filter.FilterType;
 import com.qaprosoft.zafira.models.dto.filter.Subject;
 import com.qaprosoft.zafira.services.exceptions.ServiceException;
 import com.qaprosoft.zafira.services.services.application.FilterService;
+import com.qaprosoft.zafira.ws.controller.AbstractController;
 import com.qaprosoft.zafira.ws.swagger.annotations.ResponseStatusDetails;
-
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiImplicitParam;
 import io.swagger.annotations.ApiImplicitParams;
 import io.swagger.annotations.ApiOperation;
+import org.dozer.Mapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
-@Controller
-@Api(value = "Filters API")
+import javax.validation.Valid;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Api("Filters API")
 @CrossOrigin
-@RequestMapping("api/filters")
-public class FiltersAPIController extends AbstractController
-{
+@RequestMapping(path = "api/filters", produces = MediaType.APPLICATION_JSON_VALUE)
+@RestController
+public class FiltersAPIController extends AbstractController {
 
-	@Autowired
-	private FilterService filterService;
+    @Autowired
+    private FilterService filterService;
 
-	@Autowired
-	private Mapper mapper;
+    @Autowired
+    private Mapper mapper;
 
-	@ResponseStatusDetails
-	@ApiOperation(value = "Create filter", nickname = "createFilter", httpMethod = "POST", response = FilterType.class)
-	@ResponseStatus(HttpStatus.OK)
-	@ApiImplicitParams({ @ApiImplicitParam(name = "Authorization", paramType = "header") })
-	@RequestMapping(method = RequestMethod.POST, produces = MediaType.APPLICATION_JSON_VALUE)
-	public @ResponseBody
-    FilterType createFilter(@RequestBody @Valid FilterType filterType) throws ServiceException
-	{
-		if(filterService.getFilterByName(filterType.getName()) != null)
-		{
-			throw new ServiceException("Filter with name '" + filterType.getName() + "' already exists");
-		}
-		if(filterType.isPublicAccess() && ! isAdmin())
-		{
-			filterType.setPublicAccess(false);
-		}
-		filterType.getSubject().sortCriterias();
-		Filter filter = mapper.map(filterType, Filter.class);
-		filter.setUserId(getPrincipalId());
-		return mapper.map(filterService.createFilter(filter), FilterType.class);
-	}
+    @ResponseStatusDetails
+    @ApiOperation(value = "Create filter", nickname = "createFilter", httpMethod = "POST", response = FilterType.class)
+    @ApiImplicitParams({@ApiImplicitParam(name = "Authorization", paramType = "header")})
+    @PostMapping()
+    public FilterType createFilter(@RequestBody @Valid FilterType filterType) throws ServiceException {
+        if (filterService.getFilterByName(filterType.getName()) != null) {
+            throw new ServiceException("Filter with name '" + filterType.getName() + "' already exists");
+        }
+        if (filterType.isPublicAccess() && !isAdmin()) {
+            filterType.setPublicAccess(false);
+        }
+        filterType.getSubject().sortCriterias();
+        Filter filter = mapper.map(filterType, Filter.class);
+        filter.setUserId(getPrincipalId());
+        return mapper.map(filterService.createFilter(filter), FilterType.class);
+    }
 
-	@ResponseStatusDetails
-	@ApiOperation(value = "Get all public filters", nickname = "getAllPublicFilters", httpMethod = "GET", response = List.class)
-	@ResponseStatus(HttpStatus.OK)
-	@ApiImplicitParams({ @ApiImplicitParam(name = "Authorization", paramType = "header") })
-	@RequestMapping(value = "all/public", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-	public @ResponseBody List<FilterType> getAllPublicFilters() throws ServiceException
-	{
-		return filterService.getAllPublicFilters(getPrincipalId()).stream().map(filter -> mapper.map(filter, FilterType.class))
-				.collect(Collectors.toList());
-	}
+    @ResponseStatusDetails
+    @ApiOperation(value = "Get all public filters", nickname = "getAllPublicFilters", httpMethod = "GET", response = List.class)
+    @ApiImplicitParams({@ApiImplicitParam(name = "Authorization", paramType = "header")})
+    @GetMapping("/all/public")
+    public List<FilterType> getAllPublicFilters() throws ServiceException {
+        return filterService.getAllPublicFilters(getPrincipalId()).stream()
+                            .map(filter -> mapper.map(filter, FilterType.class))
+                            .collect(Collectors.toList());
+    }
 
-	@ResponseStatusDetails
-	@ApiOperation(value = "Update filter", nickname = "updateFilter", httpMethod = "PUT", response = FilterType.class)
-	@ResponseStatus(HttpStatus.OK)
-	@ApiImplicitParams({ @ApiImplicitParam(name = "Authorization", paramType = "header") })
-	@PreAuthorize("isOwner(@filterService.getFilterById(#filterType.id), 'userId')")
-	@RequestMapping(method = RequestMethod.PUT, produces = MediaType.APPLICATION_JSON_VALUE)
-	public @ResponseBody
-    FilterType updateFilter(@RequestBody @Valid FilterType filterType) throws ServiceException
-	{
-		filterType.getSubject().sortCriterias();
-		return mapper.map(filterService.updateFilter(mapper.map(filterType, Filter.class), isAdmin()), FilterType.class);
-	}
+    @ResponseStatusDetails
+    @ApiOperation(value = "Update filter", nickname = "updateFilter", httpMethod = "PUT", response = FilterType.class)
+    @ApiImplicitParams({@ApiImplicitParam(name = "Authorization", paramType = "header")})
+    @PreAuthorize("isOwner(@filterService.getFilterById(#filterType.id), 'userId')")
+    @PutMapping()
+    public FilterType updateFilter(@RequestBody @Valid FilterType filterType) throws ServiceException {
+        filterType.getSubject().sortCriterias();
+        return mapper.map(filterService.updateFilter(mapper.map(filterType, Filter.class), isAdmin()), FilterType.class);
+    }
 
-	@ResponseStatusDetails
-	@ApiOperation(value = "Delete filter", nickname = "deleteFilter", httpMethod = "DELETE")
-	@ResponseStatus(HttpStatus.OK)
-	@ApiImplicitParams({ @ApiImplicitParam(name = "Authorization", paramType = "header") })
-	@PreAuthorize("isOwner(@filterService.getFilterById(#id), 'userId')")
-	@RequestMapping(value = "{id}", method = RequestMethod.DELETE)
-	public void deleteFilter(@PathVariable(value = "id") Long id) throws ServiceException
-	{
-		filterService.deleteFilterById(id);
-	}
+    @ResponseStatusDetails
+    @ApiOperation(value = "Delete filter", nickname = "deleteFilter", httpMethod = "DELETE")
+    @ApiImplicitParams({@ApiImplicitParam(name = "Authorization", paramType = "header")})
+    @PreAuthorize("isOwner(@filterService.getFilterById(#id), 'userId')")
+    @DeleteMapping("/{id}")
+    public void deleteFilter(@PathVariable("id") Long id) throws ServiceException {
+        filterService.deleteFilterById(id);
+    }
 
-	@ResponseStatusDetails
-	@ApiOperation(value = "Get filter builder", nickname = "getBuilder", httpMethod = "GET", response = Subject.class)
-	@ResponseStatus(HttpStatus.OK)
-	@ApiImplicitParams({ @ApiImplicitParam(name = "Authorization", paramType = "header") })
-	@RequestMapping(value = "{name}/builder", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-	public @ResponseBody
-    Subject getBuilder(@PathVariable(value = "name")Subject.Name name)
-	{
-		return filterService.getStoredSubject(name);
-	}
+    @ResponseStatusDetails
+    @ApiOperation(value = "Get filter builder", nickname = "getBuilder", httpMethod = "GET", response = Subject.class)
+    @ApiImplicitParams({@ApiImplicitParam(name = "Authorization", paramType = "header")})
+    @GetMapping("/{name}/builder")
+    public Subject getBuilder(@PathVariable("name") Subject.Name name) {
+        return filterService.getStoredSubject(name);
+    }
+
 }

--- a/sources/zafira-ws/src/main/java/com/qaprosoft/zafira/ws/controller/application/GroupsAPIController.java
+++ b/sources/zafira-ws/src/main/java/com/qaprosoft/zafira/ws/controller/application/GroupsAPIController.java
@@ -15,39 +15,37 @@
  *******************************************************************************/
 package com.qaprosoft.zafira.ws.controller.application;
 
-import java.util.List;
-
+import com.qaprosoft.zafira.models.db.Group;
 import com.qaprosoft.zafira.services.exceptions.EntityNotExistsException;
 import com.qaprosoft.zafira.services.exceptions.ForbiddenOperationException;
-import com.qaprosoft.zafira.ws.controller.AbstractController;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
-import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.CrossOrigin;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.ResponseBody;
-import org.springframework.web.bind.annotation.ResponseStatus;
-
-import com.qaprosoft.zafira.models.db.Group;
 import com.qaprosoft.zafira.services.exceptions.ServiceException;
 import com.qaprosoft.zafira.services.services.application.GroupService;
+import com.qaprosoft.zafira.ws.controller.AbstractController;
 import com.qaprosoft.zafira.ws.swagger.annotations.ResponseStatusDetails;
-
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiImplicitParam;
 import io.swagger.annotations.ApiImplicitParams;
 import io.swagger.annotations.ApiOperation;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
-@Controller
-@Api(value = "Groups API")
+import java.util.List;
+
+@Api("Groups API")
 @CrossOrigin
-@RequestMapping("api/groups")
+@RequestMapping(path = "api/groups", produces = MediaType.APPLICATION_JSON_VALUE)
+@RestController
 public class GroupsAPIController extends AbstractController {
 
     @Autowired
@@ -55,91 +53,81 @@ public class GroupsAPIController extends AbstractController {
 
     @ResponseStatusDetails
     @ApiOperation(value = "Create group", nickname = "createGroup", httpMethod = "POST", response = Group.class)
-    @ResponseStatus(HttpStatus.OK)
-    @ApiImplicitParams({ @ApiImplicitParam(name = "Authorization", paramType = "header") })
+    @ApiImplicitParams({@ApiImplicitParam(name = "Authorization", paramType = "header")})
     @PreAuthorize("hasRole('ROLE_ADMIN') and hasPermission('MODIFY_USER_GROUPS')")
-    @RequestMapping(method = RequestMethod.POST, produces = MediaType.APPLICATION_JSON_VALUE)
-    public @ResponseBody Group createGroup(@RequestBody Group group) throws ServiceException
-    {
+    @PostMapping()
+    public Group createGroup(@RequestBody Group group) throws ServiceException {
         return groupService.createGroup(group);
     }
 
     @ResponseStatusDetails
     @ApiOperation(value = "Add permissions to group", nickname = "addPermissionsToGroup", httpMethod = "POST", response = Group.class)
-    @ResponseStatus(HttpStatus.OK) @ApiImplicitParams({ @ApiImplicitParam(name = "Authorization", paramType = "header") })
+    @ApiImplicitParams({@ApiImplicitParam(name = "Authorization", paramType = "header")})
     @PreAuthorize("hasRole('ROLE_ADMIN') and hasPermission('MODIFY_USER_GROUPS')")
-    @RequestMapping(value = "permissions", method = RequestMethod.POST, produces = MediaType.APPLICATION_JSON_VALUE)
-    public @ResponseBody Group addPermissionsToGroup(@RequestBody Group group) throws ServiceException
-    {
+    @PostMapping("/permissions")
+    public Group addPermissionsToGroup(@RequestBody Group group) throws ServiceException {
         return groupService.addPermissionsToGroup(group);
     }
 
     @ResponseStatusDetails
-    @ResponseStatus(HttpStatus.OK) @ApiImplicitParams({ @ApiImplicitParam(name = "Authorization", paramType = "header") })
+    @ApiImplicitParams({@ApiImplicitParam(name = "Authorization", paramType = "header")})
     @ApiOperation(value = "Get group", nickname = "getGroup", httpMethod = "GET", response = Group.class)
     @PreAuthorize("hasPermission('MODIFY_USER_GROUPS')")
-    @RequestMapping(value = "{id}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-    public @ResponseBody Group getGroup(@PathVariable(value = "id") long id) throws ServiceException
-    {
+    @GetMapping("/{id}")
+    public Group getGroup(@PathVariable("id") long id) throws ServiceException {
         return groupService.getGroupById(id);
     }
 
     @ResponseStatusDetails
-    @ResponseStatus(HttpStatus.OK) @ApiImplicitParams({ @ApiImplicitParam(name = "Authorization", paramType = "header") })
+    @ApiImplicitParams({@ApiImplicitParam(name = "Authorization", paramType = "header")})
     @ApiOperation(value = "Get all groups", nickname = "getAllGroups", httpMethod = "GET", response = List.class)
-    @RequestMapping(value = "all", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
+    @GetMapping("/all")
     @PreAuthorize("hasPermission('MODIFY_USER_GROUPS') or #isPublic")
-    public @ResponseBody List<Group> getAllGroups(@RequestParam(value = "public", required = false) boolean isPublic) throws ServiceException
-    {
+    public List<Group> getAllGroups(@RequestParam(name = "public", required = false) boolean isPublic) throws ServiceException {
         return groupService.getAllGroups(isPublic);
     }
 
     @ResponseStatusDetails
-    @ResponseStatus(HttpStatus.OK) @ApiImplicitParams({ @ApiImplicitParam(name = "Authorization", paramType = "header") })
+    @ApiImplicitParams({@ApiImplicitParam(name = "Authorization", paramType = "header")})
     @ApiOperation(value = "Get groups count", nickname = "getGroupsCount", httpMethod = "GET", response = Integer.class)
     @PreAuthorize("hasPermission('MODIFY_USER_GROUPS')")
-    @RequestMapping(value = "count", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-    public @ResponseBody Integer getGroupsCount() throws ServiceException
-    {
+    @GetMapping("/count")
+    public Integer getGroupsCount() throws ServiceException {
         return groupService.getGroupsCount();
     }
 
     @ResponseStatusDetails
-    @ResponseStatus(HttpStatus.OK) @ApiImplicitParams({ @ApiImplicitParam(name = "Authorization", paramType = "header") })
+    @ApiImplicitParams({@ApiImplicitParam(name = "Authorization", paramType = "header")})
     @ApiOperation(value = "Get roles", nickname = "getRoles", httpMethod = "GET", response = List.class)
     @PreAuthorize("hasPermission('MODIFY_USER_GROUPS')")
-    @RequestMapping(value = "roles", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-    public @ResponseBody List<Group.Role> getRoles() throws ServiceException
-    {
+    @GetMapping("/roles")
+    public List<Group.Role> getRoles() throws ServiceException {
         return GroupService.getRoles();
     }
 
     @ResponseStatusDetails
-    @ResponseStatus(HttpStatus.OK) @ApiImplicitParams({ @ApiImplicitParam(name = "Authorization", paramType = "header") })
+    @ApiImplicitParams({@ApiImplicitParam(name = "Authorization", paramType = "header")})
     @ApiOperation(value = "Update group", nickname = "updateGroup", httpMethod = "PUT", response = Group.class)
     @PreAuthorize("hasRole('ROLE_ADMIN') and hasPermission('MODIFY_USER_GROUPS')")
-    @RequestMapping(method = RequestMethod.PUT, produces = MediaType.APPLICATION_JSON_VALUE)
-    public @ResponseBody Group updateGroup(@RequestBody Group group) throws ServiceException
-    {
+    @PutMapping()
+    public Group updateGroup(@RequestBody Group group) throws ServiceException {
         return groupService.updateGroup(group);
     }
 
     @ResponseStatusDetails
-	@ResponseStatus(HttpStatus.OK)
-	@ApiImplicitParams(
-	{ @ApiImplicitParam(name = "Authorization", paramType = "header") })
+    @ApiImplicitParams({@ApiImplicitParam(name = "Authorization", paramType = "header")})
     @ApiOperation(value = "Delete group", nickname = "deleteGroup", httpMethod = "DELETE")
     @PreAuthorize("hasRole('ROLE_ADMIN') and hasPermission('MODIFY_USER_GROUPS')")
-    @RequestMapping(value = "{id}", method = RequestMethod.DELETE)
-    public void deleteGroup(@PathVariable(value = "id") long id) throws ServiceException
-    {
+    @DeleteMapping("/{id}")
+    public void deleteGroup(@PathVariable("id") long id) throws ServiceException {
         Group group = groupService.getGroupById(id);
-        if(group == null) {
+        if (group == null) {
             throw new EntityNotExistsException(Group.class, false);
         }
-        if(group.getUsers().size() > 0) {
+        if (group.getUsers().size() > 0) {
             throw new ForbiddenOperationException("It's necessary to clear the group initially.", true);
         }
         groupService.deleteGroup(id);
     }
+
 }

--- a/sources/zafira-ws/src/main/java/com/qaprosoft/zafira/ws/controller/application/JobsAPIController.java
+++ b/sources/zafira-ws/src/main/java/com/qaprosoft/zafira/ws/controller/application/JobsAPIController.java
@@ -15,175 +15,155 @@
  *******************************************************************************/
 package com.qaprosoft.zafira.ws.controller.application;
 
-import java.util.ArrayList;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-
-import javax.validation.Valid;
-import javax.ws.rs.QueryParam;
-
-import com.qaprosoft.zafira.models.db.User;
-import com.qaprosoft.zafira.models.dto.JobUrlType;
-import com.qaprosoft.zafira.services.services.application.UserService;
-import com.qaprosoft.zafira.ws.controller.AbstractController;
-import org.apache.commons.collections4.CollectionUtils;
-import org.dozer.Mapper;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
-import org.springframework.security.access.annotation.Secured;
-import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.CrossOrigin;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.ResponseBody;
-import org.springframework.web.bind.annotation.ResponseStatus;
-
+import com.qaprosoft.zafira.models.db.AbstractEntity;
 import com.qaprosoft.zafira.models.db.Job;
 import com.qaprosoft.zafira.models.db.JobView;
 import com.qaprosoft.zafira.models.db.TestRun;
+import com.qaprosoft.zafira.models.db.User;
 import com.qaprosoft.zafira.models.dto.JobType;
+import com.qaprosoft.zafira.models.dto.JobUrlType;
 import com.qaprosoft.zafira.models.dto.JobViewType;
 import com.qaprosoft.zafira.services.exceptions.ServiceException;
 import com.qaprosoft.zafira.services.services.application.JobsService;
 import com.qaprosoft.zafira.services.services.application.TestRunService;
+import com.qaprosoft.zafira.services.services.application.UserService;
+import com.qaprosoft.zafira.ws.controller.AbstractController;
 import com.qaprosoft.zafira.ws.swagger.annotations.ResponseStatusDetails;
-
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiImplicitParam;
 import io.swagger.annotations.ApiImplicitParams;
 import io.swagger.annotations.ApiOperation;
+import org.apache.commons.collections4.CollectionUtils;
+import org.dozer.Mapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.annotation.Secured;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
-@Controller
-@Api(value = "Jobs API")
+import javax.validation.Valid;
+import javax.ws.rs.QueryParam;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Api("Jobs API")
 @CrossOrigin
-@RequestMapping("api/jobs")
-public class JobsAPIController extends AbstractController
-{
+@RequestMapping(path = "api/jobs", produces = MediaType.APPLICATION_JSON_VALUE)
+@RestController
+public class JobsAPIController extends AbstractController {
 
-	@Autowired
-	private Mapper mapper;
+    @Autowired
+    private Mapper mapper;
 
-	@Autowired
-	private JobsService jobsService;
+    @Autowired
+    private JobsService jobsService;
 
-	@Autowired
-	private TestRunService testRunService;
+    @Autowired
+    private TestRunService testRunService;
 
-	@Autowired
-	private UserService userService;
+    @Autowired
+    private UserService userService;
 
-	@ResponseStatusDetails
-	@ApiOperation(value = "Create job", nickname = "createJob", httpMethod = "POST", response = JobType.class)
-	@ResponseStatus(HttpStatus.OK) @ApiImplicitParams({ @ApiImplicitParam(name = "Authorization", paramType = "header") })
-	@RequestMapping(method = RequestMethod.POST, produces = MediaType.APPLICATION_JSON_VALUE)
-	public @ResponseBody JobType createJob(@RequestBody @Valid JobType job,
-			@RequestHeader(value = "Project", required = false) String project) throws
-			ServiceException
-	{
-		return mapper.map(jobsService.createOrUpdateJob(mapper.map(job, Job.class)), JobType.class);
-	}
+    @ResponseStatusDetails
+    @ApiOperation(value = "Create job", nickname = "createJob", httpMethod = "POST", response = JobType.class)
+    @ApiImplicitParams({@ApiImplicitParam(name = "Authorization", paramType = "header")})
+    @PostMapping()
+    public JobType createJob(@RequestBody @Valid JobType job) throws ServiceException {
+        return mapper.map(jobsService.createOrUpdateJob(mapper.map(job, Job.class)), JobType.class);
+    }
 
-	@ResponseStatusDetails
-	@ApiOperation(value = "Create job by url", nickname = "createJobByUrl", httpMethod = "POST", response = JobType.class)
-	@ResponseStatus(HttpStatus.OK) @ApiImplicitParams({ @ApiImplicitParam(name = "Authorization", paramType = "header") })
-	@RequestMapping(value = "url", method = RequestMethod.POST, produces = MediaType.APPLICATION_JSON_VALUE)
-	public @ResponseBody JobType createJobByUrl(@RequestBody @Valid JobUrlType jobUrl) throws ServiceException
-	{
-		User user = userService.getUserById(getPrincipalId());
-		return mapper.map(jobsService.createOrUpdateJobByURL(jobUrl.getJobUrlValue(), user), JobType.class);
-	}
+    @ResponseStatusDetails
+    @ApiOperation(value = "Create job by url", nickname = "createJobByUrl", httpMethod = "POST", response = JobType.class)
+    @ApiImplicitParams({@ApiImplicitParam(name = "Authorization", paramType = "header")})
+    @PostMapping("/url")
+    public JobType createJobByUrl(@RequestBody @Valid JobUrlType jobUrl) throws ServiceException {
+        User user = userService.getUserById(getPrincipalId());
+        return mapper.map(jobsService.createOrUpdateJobByURL(jobUrl.getJobUrlValue(), user), JobType.class);
+    }
 
-	@ResponseStatusDetails
-	@ApiOperation(value = "Get all jobs", nickname = "getAllJobs", httpMethod = "GET", response = List.class)
-	@ResponseStatus(HttpStatus.OK) @ApiImplicitParams({ @ApiImplicitParam(name = "Authorization", paramType = "header") })
-	@RequestMapping(method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-	public @ResponseBody List<Job> getAllJobs() throws ServiceException
-	{
-		return jobsService.getAllJobs();
-	}
+    @ResponseStatusDetails
+    @ApiOperation(value = "Get all jobs", nickname = "getAllJobs", httpMethod = "GET", response = List.class)
+    @ApiImplicitParams({@ApiImplicitParam(name = "Authorization", paramType = "header")})
+    @GetMapping()
+    public List<Job> getAllJobs() throws ServiceException {
+        return jobsService.getAllJobs();
+    }
 
-	@ResponseStatusDetails
-	@ApiOperation(value = "Get latest job test runs", nickname = "getLatestJobTestRuns", httpMethod = "POST", response = Map.class)
-	@ResponseStatus(HttpStatus.OK) @ApiImplicitParams({ @ApiImplicitParam(name = "Authorization", paramType = "header") })
-	@RequestMapping(value = "views/{id}/tests/runs", method = RequestMethod.POST, produces = MediaType.APPLICATION_JSON_VALUE)
-	public @ResponseBody Map<Long, TestRun> getLatestJobTestRuns(@QueryParam("env") String env,
-			@RequestBody @Valid List<JobViewType> jobViews) throws ServiceException
-	{
-		List<Long> jobIds = new ArrayList<>();
-		for (JobViewType jobView : jobViews)
-		{
-			jobIds.add(jobView.getJob().getId());
-		}
-		return testRunService.getLatestJobTestRuns(env, jobIds);
-	}
+    @ResponseStatusDetails
+    @ApiOperation(value = "Get latest job test runs", nickname = "getLatestJobTestRuns", httpMethod = "POST", response = Map.class)
+    @ApiImplicitParams({@ApiImplicitParam(name = "Authorization", paramType = "header")})
+    @PostMapping("/views/{id}/tests/runs")
+    public Map<Long, TestRun> getLatestJobTestRuns(@QueryParam("env") String env, @RequestBody @Valid List<JobViewType> jobViews) throws ServiceException {
+        List<Long> jobIds = jobViews.stream()
+                                    .map(JobViewType::getJob)
+                                    .map(AbstractEntity::getId)
+                                    .collect(Collectors.toList());
+        return testRunService.getLatestJobTestRuns(env, jobIds);
+    }
 
-	@ResponseStatusDetails
-	@ApiOperation(value = "Create job view", nickname = "createJobViews", httpMethod = "POST", response = List.class)
-	@ResponseStatus(HttpStatus.OK) @ApiImplicitParams({ @ApiImplicitParam(name = "Authorization", paramType = "header") })
-	@RequestMapping(value = "views", method = RequestMethod.POST, produces = MediaType.APPLICATION_JSON_VALUE)
-	@Secured({ "ROLE_ADMIN" })
-	public @ResponseBody List<JobViewType> createJobViews(@RequestBody @Valid List<JobViewType> jobViews)
-			throws ServiceException
-	{
-		for (JobViewType jobView : jobViews)
-		{
-			jobView = mapper.map(jobsService.createJobView(mapper.map(jobView, JobView.class)), JobViewType.class);
-		}
-		return jobViews;
-	}
+    @ResponseStatusDetails
+    @ApiOperation(value = "Create job view", nickname = "createJobViews", httpMethod = "POST", response = List.class)
+    @ApiImplicitParams({@ApiImplicitParam(name = "Authorization", paramType = "header")})
+    @PostMapping("/views")
+    @Secured({"ROLE_ADMIN"})
+    public List<JobViewType> createJobViews(@RequestBody @Valid List<JobViewType> jobViews) throws ServiceException {
+        for (JobViewType jobView : jobViews) {
+            jobView = mapper.map(jobsService.createJobView(mapper.map(jobView, JobView.class)), JobViewType.class);
+        }
+        return jobViews;
+    }
 
-	@ResponseStatusDetails
-	@ApiOperation(value = "Update job view", nickname = "updateJobViews", httpMethod = "PUT", response = List.class)
-	@ResponseStatus(HttpStatus.OK) @ApiImplicitParams({ @ApiImplicitParam(name = "Authorization", paramType = "header") })
-	@RequestMapping(value = "views/{id}", method = RequestMethod.PUT, produces = MediaType.APPLICATION_JSON_VALUE)
-	@Secured({ "ROLE_ADMIN" })
-	public @ResponseBody List<JobViewType> updateJobViews(@RequestBody @Valid List<JobViewType> jobViews,
-			@PathVariable(value = "id") long viewId, @QueryParam("env") String env) throws ServiceException
-	{
-		if (!CollectionUtils.isEmpty(jobViews))
-		{
-			jobsService.deleteJobViews(viewId, env);
-			for (JobViewType jobView : jobViews)
-			{
-				jobView = mapper.map(jobsService.createJobView(mapper.map(jobView, JobView.class)), JobViewType.class);
-			}
-		}
-		return jobViews;
-	}
+    @ResponseStatusDetails
+    @ApiOperation(value = "Update job view", nickname = "updateJobViews", httpMethod = "PUT", response = List.class)
+    @ApiImplicitParams({@ApiImplicitParam(name = "Authorization", paramType = "header")})
+    @PutMapping("/views/{id}")
+    @Secured({"ROLE_ADMIN"})
+    public List<JobViewType> updateJobViews(
+            @RequestBody @Valid List<JobViewType> jobViews,
+            @PathVariable("id") long viewId,
+            @QueryParam("env") String env
+    ) throws ServiceException {
+        if (!CollectionUtils.isEmpty(jobViews)) {
+            jobsService.deleteJobViews(viewId, env);
+            for (JobViewType jobView : jobViews) {
+                jobView = mapper.map(jobsService.createJobView(mapper.map(jobView, JobView.class)), JobViewType.class);
+            }
+        }
+        return jobViews;
+    }
 
-	@ResponseStatusDetails
-	@ApiOperation(value = "Get job views", nickname = "getJobViews", httpMethod = "GET", response = Map.class)
-	@ResponseStatus(HttpStatus.OK) @ApiImplicitParams({ @ApiImplicitParam(name = "Authorization", paramType = "header") })
-	@RequestMapping(value = "views/{id}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-	public @ResponseBody Map<String, List<JobViewType>> getJobViews(@PathVariable(value = "id") long id)
-			throws ServiceException
-	{
-		Map<String, List<JobViewType>> jobViews = new LinkedHashMap<>();
-		for (JobView jobView : jobsService.getJobViewsByViewId(id))
-		{
-			if (!jobViews.containsKey(jobView.getEnv()))
-			{
-				jobViews.put(jobView.getEnv(), new ArrayList<>());
-			}
-			jobViews.get(jobView.getEnv()).add(mapper.map(jobView, JobViewType.class));
-		}
-		return jobViews;
-	}
+    @ResponseStatusDetails
+    @ApiOperation(value = "Get job views", nickname = "getJobViews", httpMethod = "GET", response = Map.class)
+    @ApiImplicitParams({@ApiImplicitParam(name = "Authorization", paramType = "header")})
+    @GetMapping("/views/{id}")
+    public Map<String, List<JobViewType>> getJobViews(@PathVariable("id") long id)
+            throws ServiceException {
+        Map<String, List<JobViewType>> jobViews = new LinkedHashMap<>();
+        for (JobView jobView : jobsService.getJobViewsByViewId(id)) {
+            if (!jobViews.containsKey(jobView.getEnv())) {
+                jobViews.put(jobView.getEnv(), new ArrayList<>());
+            }
+            jobViews.get(jobView.getEnv()).add(mapper.map(jobView, JobViewType.class));
+        }
+        return jobViews;
+    }
 
-	@ResponseStatusDetails
-	@ApiOperation(value = "Delete job views", nickname = "deleteJobViews", httpMethod = "DELETE")
-	@ResponseStatus(HttpStatus.OK)
-	@ApiImplicitParams(
-	{ @ApiImplicitParam(name = "Authorization", paramType = "header") })
-	@RequestMapping(value = "views/{id}", method = RequestMethod.DELETE)
-	public void deleteJobViews(@PathVariable(value = "id") long viewId, @QueryParam("env") String env)
-			throws ServiceException
-	{
-		jobsService.deleteJobViews(viewId, env);
-	}
+    @ResponseStatusDetails
+    @ApiOperation(value = "Delete job views", nickname = "deleteJobViews", httpMethod = "DELETE")
+    @ApiImplicitParams({@ApiImplicitParam(name = "Authorization", paramType = "header")})
+    @DeleteMapping("views/{id}")
+    public void deleteJobViews(@PathVariable("id") long viewId, @QueryParam("env") String env) throws ServiceException {
+        jobsService.deleteJobViews(viewId, env);
+    }
+
 }

--- a/sources/zafira-ws/src/main/java/com/qaprosoft/zafira/ws/controller/application/LaunchersAPIController.java
+++ b/sources/zafira-ws/src/main/java/com/qaprosoft/zafira/ws/controller/application/LaunchersAPIController.java
@@ -15,44 +15,47 @@
  ******************************************************************************/
 package com.qaprosoft.zafira.ws.controller.application;
 
-import java.io.IOException;
-import java.util.List;
-import java.util.stream.Collectors;
-
-import javax.validation.Valid;
-
-import com.qaprosoft.zafira.models.dto.CreateLauncherParamsType;
-import org.dozer.Mapper;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
-import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.*;
-
 import com.qaprosoft.zafira.models.db.Launcher;
 import com.qaprosoft.zafira.models.db.User;
+import com.qaprosoft.zafira.models.dto.CreateLauncherParamsType;
 import com.qaprosoft.zafira.models.dto.LauncherType;
 import com.qaprosoft.zafira.services.exceptions.ServiceException;
 import com.qaprosoft.zafira.services.services.application.LauncherService;
 import com.qaprosoft.zafira.services.services.application.UserService;
 import com.qaprosoft.zafira.ws.controller.AbstractController;
 import com.qaprosoft.zafira.ws.swagger.annotations.ResponseStatusDetails;
-
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiImplicitParam;
 import io.swagger.annotations.ApiImplicitParams;
 import io.swagger.annotations.ApiOperation;
+import org.dozer.Mapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
-@Controller
-@Api(value = "Launchers API")
+import javax.validation.Valid;
+import java.io.IOException;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Api("Launchers API")
 @CrossOrigin
-@RequestMapping("api/launchers")
+@RequestMapping(path = "api/launchers", produces = MediaType.APPLICATION_JSON_VALUE)
+@RestController
 public class LaunchersAPIController extends AbstractController {
 
     @Autowired
     private LauncherService launcherService;
-    
+
     @Autowired
     private UserService userService;
 
@@ -61,71 +64,67 @@ public class LaunchersAPIController extends AbstractController {
 
     @ResponseStatusDetails
     @ApiOperation(value = "Create launcher", nickname = "createLauncher", httpMethod = "POST", response = LauncherType.class)
-    @ResponseStatus(HttpStatus.OK)
-    @ApiImplicitParams({ @ApiImplicitParam(name = "Authorization", paramType = "header") })
+    @ApiImplicitParams({@ApiImplicitParam(name = "Authorization", paramType = "header")})
     @PreAuthorize("hasPermission('MODIFY_LAUNCHERS')")
-    @RequestMapping(method = RequestMethod.POST, produces = MediaType.APPLICATION_JSON_VALUE)
-    public @ResponseBody LauncherType createLauncher(@RequestBody @Valid LauncherType launcherType) throws ServiceException {
+    @PostMapping()
+    public LauncherType createLauncher(@RequestBody @Valid LauncherType launcherType) throws ServiceException {
         User owner = new User(getPrincipalId());
         return mapper.map(launcherService.createLauncher(mapper.map(launcherType, Launcher.class), owner), LauncherType.class);
     }
 
     @ResponseStatusDetails
     @ApiOperation(value = "Create launcher from Jenkins", nickname = "createLauncherFromJenkins", httpMethod = "POST", response = LauncherType.class)
-    @ResponseStatus(HttpStatus.OK)
-    @ApiImplicitParams({ @ApiImplicitParam(name = "Authorization", paramType = "header") })
-    @RequestMapping(value = "create", method = RequestMethod.POST, produces = MediaType.APPLICATION_JSON_VALUE)
-    public @ResponseBody LauncherType createLauncherFromJenkins(@RequestBody @Valid CreateLauncherParamsType createLauncherParamsType) throws ServiceException {
+    @ApiImplicitParams({@ApiImplicitParam(name = "Authorization", paramType = "header")})
+    @PostMapping("/create")
+    public LauncherType createLauncherFromJenkins(@RequestBody @Valid CreateLauncherParamsType createLauncherParamsType) throws ServiceException {
         User owner = new User(getPrincipalId());
         return mapper.map(launcherService.createLauncherForJob(createLauncherParamsType, owner), LauncherType.class);
     }
 
     @ResponseStatusDetails
     @ApiOperation(value = "Get launcher by id", nickname = "getLauncherById", httpMethod = "GET", response = LauncherType.class)
-    @ResponseStatus(HttpStatus.OK)
-    @ApiImplicitParams({ @ApiImplicitParam(name = "Authorization", paramType = "header") })
+    @ApiImplicitParams({@ApiImplicitParam(name = "Authorization", paramType = "header")})
     @PreAuthorize("hasAnyPermission('MODIFY_LAUNCHERS', 'VIEW_LAUNCHERS')")
-    @RequestMapping(value = "{id}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-    public @ResponseBody LauncherType getLauncherById(@PathVariable(value = "id") Long id) throws ServiceException {
+    @GetMapping("/{id}")
+    public LauncherType getLauncherById(@PathVariable("id") Long id) throws ServiceException {
         return mapper.map(launcherService.getLauncherById(id), LauncherType.class);
     }
 
     @ResponseStatusDetails
     @ApiOperation(value = "Get all launchers", nickname = "getAllLaunchers", httpMethod = "GET", response = List.class)
-    @ResponseStatus(HttpStatus.OK)
-    @ApiImplicitParams({ @ApiImplicitParam(name = "Authorization", paramType = "header") })
+    @ApiImplicitParams({@ApiImplicitParam(name = "Authorization", paramType = "header")})
     @PreAuthorize("hasAnyPermission('MODIFY_LAUNCHERS', 'VIEW_LAUNCHERS')")
-    @RequestMapping(method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-    public @ResponseBody List<LauncherType> getAllLaunchers() throws ServiceException {
-        return launcherService.getAllLaunchers().stream().map(launcher -> mapper.map(launcher, LauncherType.class)).collect(Collectors.toList());
+    @GetMapping()
+    public List<LauncherType> getAllLaunchers() throws ServiceException {
+        return launcherService.getAllLaunchers().stream()
+                                                .map(launcher -> mapper.map(launcher, LauncherType.class))
+                                                .collect(Collectors.toList());
     }
 
     @ResponseStatusDetails
     @ApiOperation(value = "Update launcher", nickname = "updateLauncher", httpMethod = "PUT", response = LauncherType.class)
-    @ResponseStatus(HttpStatus.OK)
-    @ApiImplicitParams({ @ApiImplicitParam(name = "Authorization", paramType = "header") })
+    @ApiImplicitParams({@ApiImplicitParam(name = "Authorization", paramType = "header")})
     @PreAuthorize("hasPermission('MODIFY_LAUNCHERS')")
-    @RequestMapping(method = RequestMethod.PUT, produces = MediaType.APPLICATION_JSON_VALUE)
-    public @ResponseBody LauncherType updateLauncher(@RequestBody @Valid LauncherType launcherType) throws ServiceException {
+    @PutMapping()
+    public LauncherType updateLauncher(@RequestBody @Valid LauncherType launcherType) throws ServiceException {
         return mapper.map(launcherService.updateLauncher(mapper.map(launcherType, Launcher.class)), LauncherType.class);
     }
 
     @ResponseStatusDetails
     @ApiOperation(value = "Delete launcher by id", nickname = "deleteLauncherById", httpMethod = "DELETE")
-    @ResponseStatus(HttpStatus.OK)
-    @ApiImplicitParams({ @ApiImplicitParam(name = "Authorization", paramType = "header") })
+    @ApiImplicitParams({@ApiImplicitParam(name = "Authorization", paramType = "header")})
     @PreAuthorize("hasPermission('MODIFY_LAUNCHERS')")
-    @RequestMapping(value = "{id}", method = RequestMethod.DELETE)
-    public void deleteLauncherById(@PathVariable(value = "id") Long id) throws ServiceException {
+    @DeleteMapping("/{id}")
+    public void deleteLauncherById(@PathVariable("id") Long id) throws ServiceException {
         launcherService.deleteLauncherById(id);
     }
 
     @ResponseStatusDetails
     @ApiOperation(value = "Build job with launcher", nickname = "build", httpMethod = "POST")
-    @ResponseStatus(HttpStatus.OK)
-    @ApiImplicitParams({ @ApiImplicitParam(name = "Authorization", paramType = "header") })
-    @RequestMapping(value = "build", method = RequestMethod.POST, produces = MediaType.APPLICATION_JSON_VALUE)
+    @ApiImplicitParams({@ApiImplicitParam(name = "Authorization", paramType = "header")})
+    @PostMapping("/build")
     public void build(@RequestBody @Valid LauncherType launcherType) throws ServiceException, IOException {
         launcherService.buildLauncherJob(mapper.map(launcherType, Launcher.class), userService.getNotNullUserById(getPrincipalId()));
     }
+
 }

--- a/sources/zafira-ws/src/main/java/com/qaprosoft/zafira/ws/controller/application/MonitorsApiController.java
+++ b/sources/zafira-ws/src/main/java/com/qaprosoft/zafira/ws/controller/application/MonitorsApiController.java
@@ -15,159 +15,146 @@
  *******************************************************************************/
 package com.qaprosoft.zafira.ws.controller.application;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.stream.Collectors;
-
-import javax.validation.Valid;
-
 import com.qaprosoft.zafira.dbaccess.dao.mysql.application.search.MonitorSearchCriteria;
 import com.qaprosoft.zafira.dbaccess.dao.mysql.application.search.SearchResult;
-import com.qaprosoft.zafira.models.dto.monitor.MonitorCheckType;
-import com.qaprosoft.zafira.ws.controller.AbstractController;
-import org.dozer.Mapper;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
-import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.CrossOrigin;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.ResponseBody;
-import org.springframework.web.bind.annotation.ResponseStatus;
-
 import com.qaprosoft.zafira.models.db.Group;
 import com.qaprosoft.zafira.models.db.Monitor;
+import com.qaprosoft.zafira.models.dto.monitor.MonitorCheckType;
 import com.qaprosoft.zafira.models.dto.monitor.MonitorType;
 import com.qaprosoft.zafira.services.exceptions.ServiceException;
 import com.qaprosoft.zafira.services.services.application.MonitorService;
+import com.qaprosoft.zafira.ws.controller.AbstractController;
 import com.qaprosoft.zafira.ws.swagger.annotations.ResponseStatusDetails;
-
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiImplicitParam;
 import io.swagger.annotations.ApiImplicitParams;
 import io.swagger.annotations.ApiOperation;
+import org.dozer.Mapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
-@Controller
-@Api(value = "Monitors API")
+import javax.validation.Valid;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Api("Monitors API")
 @CrossOrigin
-@RequestMapping("api/monitors")
-public class MonitorsApiController extends AbstractController
-{
+@RequestMapping(path = "api/monitors", produces = MediaType.APPLICATION_JSON_VALUE)
+@RestController
+public class MonitorsApiController extends AbstractController {
 
-	@Autowired
-	private MonitorService monitorsService;
+    @Autowired
+    private MonitorService monitorsService;
 
-	@Autowired
-	private Mapper mapper;
+    @Autowired
+    private Mapper mapper;
 
-	@ResponseStatusDetails
-	@ApiOperation(value = "Create monitor", nickname = "createMonitor", httpMethod = "POST", response = Monitor.class)
-	@ResponseStatus(HttpStatus.OK)
-	@ApiImplicitParams({ @ApiImplicitParam(name = "Authorization", paramType = "header") })
-	@PreAuthorize("hasPermission('MODIFY_MONITORS')")
-	@RequestMapping(method = RequestMethod.POST, produces = MediaType.APPLICATION_JSON_VALUE)
-	public @ResponseBody
-	MonitorType createMonitor(@Valid @RequestBody MonitorType monitor) throws ServiceException
-	{
-		return mapper.map(monitorsService.createMonitor(mapper.map(monitor, Monitor.class)), MonitorType.class);
-	}
+    @ResponseStatusDetails
+    @ApiOperation(value = "Create monitor", nickname = "createMonitor", httpMethod = "POST", response = Monitor.class)
+    @ApiImplicitParams({@ApiImplicitParam(name = "Authorization", paramType = "header")})
+    @PreAuthorize("hasPermission('MODIFY_MONITORS')")
+    @PostMapping()
+    public MonitorType createMonitor(@Valid @RequestBody MonitorType monitor) throws ServiceException {
+        return mapper.map(monitorsService.createMonitor(mapper.map(monitor, Monitor.class)), MonitorType.class);
+    }
 
-	@ResponseStatusDetails
-	@ApiOperation(value = "Check monitor", nickname = "checkMonitor", httpMethod = "POST", response = MonitorCheckType.class)
-	@ResponseStatus(HttpStatus.OK)
-	@ApiImplicitParams({ @ApiImplicitParam(name = "Authorization", paramType = "header") })
-	@PreAuthorize("hasPermission('MODIFY_MONITORS')")
-	@RequestMapping(value = "check", method = RequestMethod.POST, produces = MediaType.APPLICATION_JSON_VALUE)
-	public @ResponseBody MonitorCheckType checkMonitor(@RequestParam(value = "check", required = false) Boolean check, @Valid @RequestBody MonitorType monitor) throws ServiceException
-	{
-		return monitorsService.checkMonitor(mapper.map(monitor, Monitor.class), check);
-	}
+    @ResponseStatusDetails
+    @ApiOperation(value = "Check monitor", nickname = "checkMonitor", httpMethod = "POST", response = MonitorCheckType.class)
+    @ApiImplicitParams({@ApiImplicitParam(name = "Authorization", paramType = "header")})
+    @PreAuthorize("hasPermission('MODIFY_MONITORS')")
+    @PostMapping("/check")
+    public MonitorCheckType checkMonitor(
+            @RequestParam(value = "check", required = false) Boolean check,
+            @Valid @RequestBody MonitorType monitor
+    ) throws ServiceException {
+        return monitorsService.checkMonitor(mapper.map(monitor, Monitor.class), check);
+    }
 
-	@ResponseStatusDetails
-	@ApiOperation(value = "Search monitors", nickname = "searchMonitors", httpMethod = "POST", response = SearchResult.class)
-	@ResponseStatus(HttpStatus.OK)
-	@ApiImplicitParams({ @ApiImplicitParam(name = "Authorization", paramType = "header") })
-	@PreAuthorize("hasPermission('VIEW_MONITORS')")
-	@RequestMapping(value = "search", method = RequestMethod.POST, produces = MediaType.APPLICATION_JSON_VALUE)
-	public @ResponseBody SearchResult<MonitorType> searchMonitors(@RequestBody MonitorSearchCriteria sc)
-	{
-		SearchResult<Monitor> sr = monitorsService.searchMonitors(sc);
-		SearchResult<MonitorType> result = new SearchResult<>();
-		result.setTotalResults(sr.getTotalResults());
-		result.setSortOrder(sr.getSortOrder());
-		result.setPageSize(sr.getPageSize());
-		result.setPage(sr.getPage());
-		result.setResults(sr.getResults().stream().map(monitor -> mapper.map(monitor, MonitorType.class)).collect(
-				Collectors.toList()));
-		return result;
-	}
+    @ResponseStatusDetails
+    @ApiOperation(value = "Search monitors", nickname = "searchMonitors", httpMethod = "POST", response = SearchResult.class)
+    @ApiImplicitParams({@ApiImplicitParam(name = "Authorization", paramType = "header")})
+    @PreAuthorize("hasPermission('VIEW_MONITORS')")
+    @PostMapping("/search")
+    public SearchResult<MonitorType> searchMonitors(@RequestBody MonitorSearchCriteria searchCriteria) {
+        SearchResult<Monitor> searchResult = monitorsService.searchMonitors(searchCriteria);
 
-	@ResponseStatusDetails
-	@ApiOperation(value = "Delete monitor", nickname = "deleteMonitor", httpMethod = "DELETE")
-	@ResponseStatus(HttpStatus.OK)
-	@ApiImplicitParams({ @ApiImplicitParam(name = "Authorization", paramType = "header") })
-	@PreAuthorize("hasPermission('MODIFY_MONITORS')")
-	@RequestMapping(value = "{id}", method = RequestMethod.DELETE)
-	public void deleteMonitor(@PathVariable(value = "id") long id)
-	{
-		monitorsService.deleteMonitorById(id);
-	}
+        SearchResult<MonitorType> result = new SearchResult<>();
+        result.setTotalResults(searchResult.getTotalResults());
+        result.setSortOrder(searchResult.getSortOrder());
+        result.setPageSize(searchResult.getPageSize());
+        result.setPage(searchResult.getPage());
+        List<MonitorType> results = searchResult.getResults().stream()
+                                                   .map(monitor -> mapper.map(monitor, MonitorType.class))
+                                                   .collect(Collectors.toList());
+        result.setResults(results);
 
-	@ResponseStatusDetails
-	@ResponseStatus(HttpStatus.OK)
-	@ApiImplicitParams({ @ApiImplicitParam(name = "Authorization", paramType = "header") })
-	@ApiOperation(value = "Update monitor", nickname = "updateMonitor", httpMethod = "PUT", response = Group.class)
-	@PreAuthorize("hasPermission('MODIFY_MONITORS')")
-	@RequestMapping(method = RequestMethod.PUT, produces = MediaType.APPLICATION_JSON_VALUE)
-	public @ResponseBody MonitorType updateMonitor(@RequestParam(value = "switchJob", required = false) Boolean switchJob,
-			@Valid @RequestBody MonitorType monitor) throws ServiceException
-	{
-		return mapper.map(monitorsService.updateMonitor(mapper.map(monitor, Monitor.class), switchJob, true), MonitorType.class);
-	}
+        return result;
+    }
 
-	@ResponseStatusDetails
-	@ApiOperation(value = "Get all monitors", nickname = "getAllMonitors", httpMethod = "GET", response = List.class)
-	@ResponseStatus(HttpStatus.OK)
-	@ApiImplicitParams({ @ApiImplicitParam(name = "Authorization", paramType = "header") })
-	@PreAuthorize("hasAnyPermission('VIEW_MONITORS', 'MODIFY_MONITORS')")
-	@RequestMapping(method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-	public @ResponseBody
-	List<MonitorType> getAllMonitors() throws ServiceException
-	{
-		List<MonitorType> monitorTypes = new ArrayList<>();
-		List<Monitor> monitors = monitorsService.getAllMonitors();
-		for (Monitor monitor : monitors)
-		{
-			monitorTypes.add(mapper.map(monitor, MonitorType.class));
-		}
-		return monitorTypes;
-	}
+    @ResponseStatusDetails
+    @ApiOperation(value = "Delete monitor", nickname = "deleteMonitor", httpMethod = "DELETE")
+    @ApiImplicitParams({@ApiImplicitParam(name = "Authorization", paramType = "header")})
+    @PreAuthorize("hasPermission('MODIFY_MONITORS')")
+    @DeleteMapping("/{id}")
+    public void deleteMonitor(@PathVariable("id") long id) {
+        monitorsService.deleteMonitorById(id);
+    }
 
-	@ResponseStatusDetails
-	@ResponseStatus(HttpStatus.OK)
-	@ApiImplicitParams({ @ApiImplicitParam(name = "Authorization", paramType = "header") })
-	@ApiOperation(value = "Get monitor by id", nickname = "getMonitorById", httpMethod = "GET", response = Monitor.class)
-	@PreAuthorize("hasAnyPermission('VIEW_MONITORS', 'MODIFY_MONITORS')")
-	@RequestMapping(value = "{id}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-	public @ResponseBody MonitorType getMonitorById(@PathVariable(value = "id") long id) throws ServiceException
-	{
-		return mapper.map(monitorsService.getMonitorById(id), MonitorType.class);
-	}
+    @ResponseStatusDetails
+    @ApiImplicitParams({@ApiImplicitParam(name = "Authorization", paramType = "header")})
+    @ApiOperation(value = "Update monitor", nickname = "updateMonitor", httpMethod = "PUT", response = Group.class)
+    @PreAuthorize("hasPermission('MODIFY_MONITORS')")
+    @PutMapping()
+    public MonitorType updateMonitor(
+            @RequestParam(value = "switchJob", required = false) Boolean switchJob,
+            @Valid @RequestBody MonitorType monitor
+    ) throws ServiceException {
+        return mapper.map(monitorsService.updateMonitor(mapper.map(monitor, Monitor.class), switchJob, true), MonitorType.class);
+    }
 
-	@ResponseStatusDetails
-	@ResponseStatus(HttpStatus.OK)
-	@ApiImplicitParams({ @ApiImplicitParam(name = "Authorization", paramType = "header") })
-	@ApiOperation(value = "Get monitors count", nickname = "getMonitorsCount", httpMethod = "GET", response = Integer.class)
-	@PreAuthorize("hasAnyPermission('VIEW_MONITORS', 'MODIFY_MONITORS')")
-	@RequestMapping(value = "count", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-	public @ResponseBody Integer getMonitorsCount() throws ServiceException
-	{
-		return monitorsService.getMonitorsCount();
-	}
+    @ResponseStatusDetails
+    @ApiOperation(value = "Get all monitors", nickname = "getAllMonitors", httpMethod = "GET", response = List.class)
+    @ApiImplicitParams({@ApiImplicitParam(name = "Authorization", paramType = "header")})
+    @PreAuthorize("hasAnyPermission('VIEW_MONITORS', 'MODIFY_MONITORS')")
+    @GetMapping()
+    public List<MonitorType> getAllMonitors() throws ServiceException {
+        List<MonitorType> monitorTypes = new ArrayList<>();
+        List<Monitor> monitors = monitorsService.getAllMonitors();
+        for (Monitor monitor : monitors) {
+            monitorTypes.add(mapper.map(monitor, MonitorType.class));
+        }
+        return monitorTypes;
+    }
+
+    @ResponseStatusDetails
+    @ApiImplicitParams({@ApiImplicitParam(name = "Authorization", paramType = "header")})
+    @ApiOperation(value = "Get monitor by id", nickname = "getMonitorById", httpMethod = "GET", response = Monitor.class)
+    @PreAuthorize("hasAnyPermission('VIEW_MONITORS', 'MODIFY_MONITORS')")
+    @GetMapping("/{id}")
+    public MonitorType getMonitorById(@PathVariable("id") long id) throws ServiceException {
+        return mapper.map(monitorsService.getMonitorById(id), MonitorType.class);
+    }
+
+    @ResponseStatusDetails
+    @ApiImplicitParams({@ApiImplicitParam(name = "Authorization", paramType = "header")})
+    @ApiOperation(value = "Get monitors count", nickname = "getMonitorsCount", httpMethod = "GET", response = Integer.class)
+    @PreAuthorize("hasAnyPermission('VIEW_MONITORS', 'MODIFY_MONITORS')")
+    @GetMapping("/count")
+    public Integer getMonitorsCount() throws ServiceException {
+        return monitorsService.getMonitorsCount();
+    }
+
 }
 

--- a/sources/zafira-ws/src/main/java/com/qaprosoft/zafira/ws/controller/application/PermissionsAPIController.java
+++ b/sources/zafira-ws/src/main/java/com/qaprosoft/zafira/ws/controller/application/PermissionsAPIController.java
@@ -15,47 +15,40 @@
  *******************************************************************************/
 package com.qaprosoft.zafira.ws.controller.application;
 
-import java.util.List;
-
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
-import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.CrossOrigin;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.ResponseBody;
-import org.springframework.web.bind.annotation.ResponseStatus;
-
 import com.qaprosoft.zafira.models.db.Permission;
 import com.qaprosoft.zafira.services.exceptions.ServiceException;
 import com.qaprosoft.zafira.services.services.application.PermissionService;
 import com.qaprosoft.zafira.ws.swagger.annotations.ResponseStatusDetails;
-
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiImplicitParam;
 import io.swagger.annotations.ApiImplicitParams;
 import io.swagger.annotations.ApiOperation;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
-@Controller
-@Api(value = "Permissions API")
+import java.util.List;
+
+@Api("Permissions API")
 @CrossOrigin
-@RequestMapping("api/permissions")
-public class PermissionsAPIController
-{
+@RequestMapping(path = "api/permissions", produces = MediaType.APPLICATION_JSON_VALUE)
+@RestController
+public class PermissionsAPIController {
 
-	@Autowired
-	private PermissionService permissionService;
+    @Autowired
+    private PermissionService permissionService;
 
-	@ResponseStatusDetails
-	@ApiOperation(value = "Get all permissions", nickname = "getAllPermissions", httpMethod = "GET", response = List.class)
-	@ResponseStatus(HttpStatus.OK)
-	@ApiImplicitParams({ @ApiImplicitParam(name = "Authorization", paramType = "header") })
-	@PreAuthorize("hasPermission('MODIFY_USER_GROUPS')")
-	@RequestMapping(method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-	public @ResponseBody List<Permission> getAllPermissions() throws ServiceException
-	{
-		return permissionService.getAllPermissions();
-	}
+    @ResponseStatusDetails
+    @ApiOperation(value = "Get all permissions", nickname = "getAllPermissions", httpMethod = "GET", response = List.class)
+    @ApiImplicitParams({@ApiImplicitParam(name = "Authorization", paramType = "header")})
+    @PreAuthorize("hasPermission('MODIFY_USER_GROUPS')")
+    @GetMapping()
+    public List<Permission> getAllPermissions() throws ServiceException {
+        return permissionService.getAllPermissions();
+    }
+
 }

--- a/sources/zafira-ws/src/main/java/com/qaprosoft/zafira/ws/controller/application/ProjectsAPIController.java
+++ b/sources/zafira-ws/src/main/java/com/qaprosoft/zafira/ws/controller/application/ProjectsAPIController.java
@@ -15,105 +15,98 @@
  *******************************************************************************/
 package com.qaprosoft.zafira.ws.controller.application;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import javax.validation.Valid;
-
-import com.qaprosoft.zafira.ws.controller.AbstractController;
-
-import org.dozer.Mapper;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
-import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.CrossOrigin;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.ResponseBody;
-import org.springframework.web.bind.annotation.ResponseStatus;
-
 import com.qaprosoft.zafira.models.db.Project;
 import com.qaprosoft.zafira.models.dto.ProjectType;
 import com.qaprosoft.zafira.services.exceptions.ProjectNotFoundException;
 import com.qaprosoft.zafira.services.exceptions.ServiceException;
 import com.qaprosoft.zafira.services.services.application.ProjectService;
+import com.qaprosoft.zafira.ws.controller.AbstractController;
 import com.qaprosoft.zafira.ws.swagger.annotations.ResponseStatusDetails;
-
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiImplicitParam;
 import io.swagger.annotations.ApiImplicitParams;
 import io.swagger.annotations.ApiOperation;
+import org.dozer.Mapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
-@Controller
-@Api(value = "Projects API")
+import javax.validation.Valid;
+import java.util.ArrayList;
+import java.util.List;
+
+@Api("Projects API")
 @CrossOrigin
-@RequestMapping("api/projects")
+@RequestMapping(path = "api/projects", produces = MediaType.APPLICATION_JSON_VALUE)
+@RestController
 public class ProjectsAPIController extends AbstractController {
-	@Autowired
-	private Mapper mapper;
 
-	@Autowired
-	private ProjectService projectService;
+    @Autowired
+    private Mapper mapper;
 
-	@ResponseStatusDetails
-	@ApiOperation(value = "Create project", nickname = "createProject", httpMethod = "POST", response = ProjectType.class)
-	@ResponseStatus(HttpStatus.OK)
-	@ApiImplicitParams({ @ApiImplicitParam(name = "Authorization", paramType = "header") })
-	@PreAuthorize("hasPermission('MODIFY_PROJECTS')")
-	@RequestMapping(method = RequestMethod.POST, produces = MediaType.APPLICATION_JSON_VALUE)
-	public @ResponseBody ProjectType createProject(@RequestBody @Valid ProjectType project) throws ServiceException {
-		Project newProject = projectService.createProject(mapper.map(project, Project.class));
-		return mapper.map(newProject, ProjectType.class);
-	}
+    @Autowired
+    private ProjectService projectService;
 
-	@ResponseStatusDetails
-	@ApiOperation(value = "Delete project", nickname = "deleteProject", httpMethod = "DELETE")
-	@ResponseStatus(HttpStatus.OK)
-	@ApiImplicitParams({ @ApiImplicitParam(name = "Authorization", paramType = "header") })
-	@PreAuthorize("hasPermission('MODIFY_PROJECTS')")
-	@RequestMapping(value = "{id}", method = RequestMethod.DELETE)
-	public void deleteProject(@PathVariable(value = "id") long id) throws ServiceException {
-		projectService.deleteProjectById(id);
-	}
+    @ResponseStatusDetails
+    @ApiOperation(value = "Create project", nickname = "createProject", httpMethod = "POST", response = ProjectType.class)
+    @ApiImplicitParams({@ApiImplicitParam(name = "Authorization", paramType = "header")})
+    @PreAuthorize("hasPermission('MODIFY_PROJECTS')")
+    @PostMapping()
+    public ProjectType createProject(@RequestBody @Valid ProjectType project) throws ServiceException {
+        Project newProject = projectService.createProject(mapper.map(project, Project.class));
+        return mapper.map(newProject, ProjectType.class);
+    }
 
-	@ResponseStatusDetails
-	@ApiOperation(value = "Update project", nickname = "updateProject", httpMethod = "PUT", response = ProjectType.class)
-	@ResponseStatus(HttpStatus.OK)
-	@ApiImplicitParams({ @ApiImplicitParam(name = "Authorization", paramType = "header") })
-	@PreAuthorize("hasPermission('MODIFY_PROJECTS')")
-	@RequestMapping(method = RequestMethod.PUT, produces = MediaType.APPLICATION_JSON_VALUE)
-	public @ResponseBody ProjectType updateProject(@RequestBody @Valid ProjectType project) throws ServiceException {
-		Project updatedProject = projectService.updateProject(mapper.map(project, Project.class));
-		return mapper.map(updatedProject, ProjectType.class);
-	}
+    @ResponseStatusDetails
+    @ApiOperation(value = "Delete project", nickname = "deleteProject", httpMethod = "DELETE")
+    @ApiImplicitParams({@ApiImplicitParam(name = "Authorization", paramType = "header")})
+    @PreAuthorize("hasPermission('MODIFY_PROJECTS')")
+    @DeleteMapping("/{id}")
+    public void deleteProject(@PathVariable("id") long id) throws ServiceException {
+        projectService.deleteProjectById(id);
+    }
 
-	@ResponseStatusDetails
-	@ApiOperation(value = "Get all projects", nickname = "getAllProjects", httpMethod = "GET", response = List.class)
-	@ResponseStatus(HttpStatus.OK)
-	@ApiImplicitParams({ @ApiImplicitParam(name = "Authorization", paramType = "header") })
-	@RequestMapping(method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-	public @ResponseBody List<ProjectType> getAllProjects() throws ServiceException {
-		List<ProjectType> projects = new ArrayList<>();
-		for (Project project : projectService.getAllProjects()) {
-			projects.add(mapper.map(project, ProjectType.class));
-		}
-		return projects;
-	}
-	
-	@ResponseStatusDetails
-	@ApiOperation(value = "Get project by name", nickname = "getProjectByName", httpMethod = "GET", response = ProjectType.class)
-	@ResponseStatus(HttpStatus.OK)
-	@ApiImplicitParams({ @ApiImplicitParam(name = "Authorization", paramType = "header") })
-	@RequestMapping(value = "{name}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-	public @ResponseBody ProjectType getProjectByName(@PathVariable(value = "name") String name) throws ServiceException {
-		Project project = projectService.getProjectByName(name);
-		if(project == null) {
-			throw new ProjectNotFoundException();
-		}
-		return mapper.map(project, ProjectType.class);
-	}
+    @ResponseStatusDetails
+    @ApiOperation(value = "Update project", nickname = "updateProject", httpMethod = "PUT", response = ProjectType.class)
+    @ApiImplicitParams({@ApiImplicitParam(name = "Authorization", paramType = "header")})
+    @PreAuthorize("hasPermission('MODIFY_PROJECTS')")
+    @PutMapping()
+    public ProjectType updateProject(@RequestBody @Valid ProjectType project) throws ServiceException {
+        Project updatedProject = projectService.updateProject(mapper.map(project, Project.class));
+        return mapper.map(updatedProject, ProjectType.class);
+    }
+
+    @ResponseStatusDetails
+    @ApiOperation(value = "Get all projects", nickname = "getAllProjects", httpMethod = "GET", response = List.class)
+    @ApiImplicitParams({@ApiImplicitParam(name = "Authorization", paramType = "header")})
+    @GetMapping()
+    public List<ProjectType> getAllProjects() throws ServiceException {
+        List<ProjectType> projects = new ArrayList<>();
+        for (Project project : projectService.getAllProjects()) {
+            projects.add(mapper.map(project, ProjectType.class));
+        }
+        return projects;
+    }
+
+    @ResponseStatusDetails
+    @ApiOperation(value = "Get project by name", nickname = "getProjectByName", httpMethod = "GET", response = ProjectType.class)
+    @ApiImplicitParams({@ApiImplicitParam(name = "Authorization", paramType = "header")})
+    @GetMapping("/{name}")
+    public ProjectType getProjectByName(@PathVariable("name") String name) throws ServiceException {
+        Project project = projectService.getProjectByName(name);
+        if (project == null) {
+            throw new ProjectNotFoundException();
+        }
+        return mapper.map(project, ProjectType.class);
+    }
+
 }

--- a/sources/zafira-ws/src/main/java/com/qaprosoft/zafira/ws/controller/application/ScmAPIController.java
+++ b/sources/zafira-ws/src/main/java/com/qaprosoft/zafira/ws/controller/application/ScmAPIController.java
@@ -15,29 +15,6 @@
  *******************************************************************************/
 package com.qaprosoft.zafira.ws.controller.application;
 
-import java.io.IOException;
-import java.net.URISyntaxException;
-import java.util.List;
-import java.util.stream.Collectors;
-
-import javax.validation.Valid;
-
-import org.apache.commons.lang3.StringUtils;
-import org.dozer.Mapper;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
-import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.CrossOrigin;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.ResponseBody;
-import org.springframework.web.bind.annotation.ResponseStatus;
-
 import com.qaprosoft.zafira.models.db.ScmAccount;
 import com.qaprosoft.zafira.models.dto.ScmAccountType;
 import com.qaprosoft.zafira.models.dto.scm.Organization;
@@ -48,21 +25,41 @@ import com.qaprosoft.zafira.services.services.application.scm.GitHubService;
 import com.qaprosoft.zafira.services.services.application.scm.ScmAccountService;
 import com.qaprosoft.zafira.ws.controller.AbstractController;
 import com.qaprosoft.zafira.ws.swagger.annotations.ResponseStatusDetails;
-
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiImplicitParam;
 import io.swagger.annotations.ApiImplicitParams;
 import io.swagger.annotations.ApiOperation;
+import org.apache.commons.lang3.StringUtils;
+import org.dozer.Mapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
-@Controller
-@Api(value = "SCM accounts API")
+import javax.validation.Valid;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Api("SCM accounts API")
 @CrossOrigin
-@RequestMapping("api/scm")
+@RequestMapping(path = "api/scm", produces = MediaType.APPLICATION_JSON_VALUE)
+@RestController
 public class ScmAPIController extends AbstractController {
 
     @Autowired
     private ScmAccountService scmAccountService;
-    
+
     @Autowired
     private GitHubService gitHubService;
 
@@ -71,46 +68,44 @@ public class ScmAPIController extends AbstractController {
 
     @ResponseStatusDetails
     @ApiOperation(value = "Create SCM account", nickname = "createScmAccount", httpMethod = "POST", response = ScmAccountType.class)
-    @ResponseStatus(HttpStatus.OK)
-    @ApiImplicitParams({ @ApiImplicitParam(name = "Authorization", paramType = "header") })
-    @RequestMapping(value="accounts", method = RequestMethod.POST, produces = MediaType.APPLICATION_JSON_VALUE)
-    public @ResponseBody ScmAccountType createScmAccount(@Valid @RequestBody ScmAccountType scmAccountType) throws ServiceException {
+    @ApiImplicitParams({@ApiImplicitParam(name = "Authorization", paramType = "header")})
+    @PostMapping("/accounts")
+    public ScmAccountType createScmAccount(@Valid @RequestBody ScmAccountType scmAccountType) throws ServiceException {
         return mapper.map(scmAccountService.createScmAccount(mapper.map(scmAccountType, ScmAccount.class)), ScmAccountType.class);
     }
 
     @ResponseStatusDetails
     @ApiOperation(value = "Get SCM account by id", nickname = "getScmAccountById", httpMethod = "GET", response = ScmAccountType.class)
-    @ResponseStatus(HttpStatus.OK)
-    @ApiImplicitParams({ @ApiImplicitParam(name = "Authorization", paramType = "header") })
+    @ApiImplicitParams({@ApiImplicitParam(name = "Authorization", paramType = "header")})
     @PreAuthorize("hasRole('ROLE_ADMIN')")
-    @RequestMapping(value = "accounts/{id}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-    public @ResponseBody ScmAccountType getScmAccountById(@PathVariable(value = "id") Long id) throws ServiceException {
+    @GetMapping("/accounts/{id}")
+    public ScmAccountType getScmAccountById(@PathVariable("id") Long id) throws ServiceException {
         return mapper.map(scmAccountService.getScmAccountById(id), ScmAccountType.class);
     }
 
     @ResponseStatusDetails
     @ApiOperation(value = "Get all SCM accounts", nickname = "getAllScmAccounts", httpMethod = "GET", response = List.class)
-    @ResponseStatus(HttpStatus.OK)
-    @ApiImplicitParams({ @ApiImplicitParam(name = "Authorization", paramType = "header") })
+    @ApiImplicitParams({@ApiImplicitParam(name = "Authorization", paramType = "header")})
     @PreAuthorize("hasRole('ROLE_ADMIN')")
-    @RequestMapping(value = "accounts", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-    public @ResponseBody List<ScmAccountType> getAllScmAccounts() throws ServiceException {
-        return scmAccountService.getAllScmAccounts().stream().map(scmAccount -> mapper.map(scmAccount, ScmAccountType.class)).collect(Collectors.toList());
+    @GetMapping("/accounts")
+    public List<ScmAccountType> getAllScmAccounts() throws ServiceException {
+        return scmAccountService.getAllScmAccounts().stream()
+                                .map(scmAccount -> mapper.map(scmAccount, ScmAccountType.class))
+                                .collect(Collectors.toList());
     }
 
     @ResponseStatusDetails
     @ApiOperation(value = "Update SCM account", nickname = "updateScmAccount", httpMethod = "PUT", response = ScmAccountType.class)
-    @ResponseStatus(HttpStatus.OK)
-    @ApiImplicitParams({ @ApiImplicitParam(name = "Authorization", paramType = "header") })
+    @ApiImplicitParams({@ApiImplicitParam(name = "Authorization", paramType = "header")})
     @PreAuthorize("hasRole('ROLE_ADMIN')")
-    @RequestMapping(value="accounts", method = RequestMethod.PUT, produces = MediaType.APPLICATION_JSON_VALUE)
-    public @ResponseBody ScmAccountType updateScmAccount(@RequestBody @Valid ScmAccountType scmAccountType) throws ServiceException {
+    @PutMapping("/accounts")
+    public ScmAccountType updateScmAccount(@RequestBody @Valid ScmAccountType scmAccountType) throws ServiceException {
         ScmAccount account = scmAccountService.getScmAccountById(scmAccountType.getId());
-        if(account == null) {
+        if (account == null) {
             throw new ServiceException("Scm account with id " + scmAccountType.getId() + " does not exist.");
         }
         ScmAccount currentAccount = mapper.map(scmAccountType, ScmAccount.class);
-        if(account.getUserId() == null || account.getUserId() <= 0) {
+        if (account.getUserId() == null || account.getUserId() <= 0) {
             currentAccount.setUserId(getPrincipalId());
         }
         return mapper.map(scmAccountService.updateScmAccount(currentAccount), ScmAccountType.class);
@@ -118,40 +113,37 @@ public class ScmAPIController extends AbstractController {
 
     @ResponseStatusDetails
     @ApiOperation(value = "Delete SCM account by id", nickname = "deleteScmAccountById", httpMethod = "DELETE")
-    @ResponseStatus(HttpStatus.OK)
-    @ApiImplicitParams({ @ApiImplicitParam(name = "Authorization", paramType = "header") })
+    @ApiImplicitParams({@ApiImplicitParam(name = "Authorization", paramType = "header")})
     @PreAuthorize("hasRole('ROLE_ADMIN')")
-    @RequestMapping(value = "accounts/{id}", method = RequestMethod.DELETE)
-    public void deleteScmAccountById(@PathVariable(value = "id") Long id) throws ServiceException {
+    @DeleteMapping("/accounts/{id}")
+    public void deleteScmAccountById(@PathVariable("id") Long id) throws ServiceException {
         scmAccountService.deleteScmAccountById(id);
     }
-    
+
     @ResponseStatusDetails
     @ApiOperation(value = "Get client id", nickname = "getScmClientId", httpMethod = "GET", response = String.class)
-    @ResponseStatus(HttpStatus.OK)
-    @RequestMapping(value = "github/client", method = RequestMethod.GET, produces = MediaType.TEXT_PLAIN_VALUE)
-    public @ResponseBody String getScmClientId(@RequestParam(value = "name", required = false) ScmAccount.Name name) {
+    @GetMapping(path = "github/client", produces = MediaType.TEXT_PLAIN_VALUE)
+    public String getScmClientId() {
         return gitHubService.getClientId();
     }
 
     @ResponseStatusDetails
     @ApiOperation(value = "Github callback", nickname = "callback", httpMethod = "GET", response = ScmAccountType.class)
-    @RequestMapping(value = "github/exchange", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-    public @ResponseBody ScmAccountType authorizeCallback(@RequestParam(value = "code") String code) throws IOException, URISyntaxException, ServiceException {
+    @GetMapping("/github/exchange")
+    public ScmAccountType authorizeCallback(@RequestParam("code") String code) throws IOException, URISyntaxException, ServiceException {
         String accessToken = gitHubService.getAccessToken(code);
-        if(StringUtils.isBlank(accessToken)) {
+        if (StringUtils.isBlank(accessToken)) {
             throw new ForbiddenOperationException("Cannot recognize your authority");
         }
         return mapper.map(scmAccountService.createScmAccount(new ScmAccount(accessToken, ScmAccount.Name.GITHUB, getPrincipalId())), ScmAccountType.class);
     }
-    
+
     @ResponseStatusDetails
     @ApiOperation(value = "Get all organizations", nickname = "getOrganizations", httpMethod = "GET", response = List.class)
-    @ResponseStatus(HttpStatus.OK)
-    @RequestMapping(value = "github/organizations/{scmId}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-    public @ResponseBody List<Organization> getOrganizations(@PathVariable(value = "scmId") Long id) throws IOException, ServiceException {
+    @GetMapping("/github/organizations/{scmId}")
+    public List<Organization> getOrganizations(@PathVariable("scmId") Long id) throws IOException, ServiceException {
         ScmAccount scmAccount = this.scmAccountService.getScmAccountById(id);
-        if(scmAccount == null) {
+        if (scmAccount == null) {
             throw new ForbiddenOperationException("Unable to list organizations");
         }
         return gitHubService.getOrganizations(scmAccount.getAccessToken());
@@ -159,15 +151,25 @@ public class ScmAPIController extends AbstractController {
 
     @ResponseStatusDetails
     @ApiOperation(value = "Get all repositories", nickname = "getRepositories", httpMethod = "GET", response = List.class)
-    @ResponseStatus(HttpStatus.OK)
-    @RequestMapping(value = "github/repositories/{scmId}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-    public @ResponseBody List<Repository> getRepositories(@PathVariable(value = "scmId") Long id, @RequestParam(value = "org", required = false) String organizationName) throws IOException, ServiceException {
-        ScmAccount scmAccount = this.scmAccountService.getScmAccountById(id);
-        if(scmAccount == null) {
+    @GetMapping("/github/repositories/{scmId}")
+    public List<Repository> getRepositories(
+            @PathVariable("scmId") Long id,
+            @RequestParam(value = "org", required = false) String organizationName
+    ) throws IOException, ServiceException {
+        ScmAccount scmAccount = scmAccountService.getScmAccountById(id);
+        if (scmAccount == null) {
             throw new ForbiddenOperationException("Unable to list repositories");
         }
-        List<String> scmAccounts = scmAccountService.getAllScmAccounts().stream().map(ScmAccount::getRepositoryURL).collect(Collectors.toList());
-        return gitHubService.getRepositories(this.scmAccountService.getScmAccountById(id).getAccessToken(), organizationName)
-                .stream().filter(repository -> ! scmAccounts.contains(repository.getUrl())).collect(Collectors.toList());
+
+        List<ScmAccount> allAccounts = scmAccountService.getAllScmAccounts();
+        List<String> repositoryUrls = allAccounts.stream()
+                                                 .map(ScmAccount::getRepositoryURL)
+                                                 .collect(Collectors.toList());
+
+        List<Repository> repositories = gitHubService.getRepositories(scmAccount.getAccessToken(), organizationName);
+        return repositories.stream()
+                           .filter(repository -> !repositoryUrls.contains(repository.getUrl()))
+                           .collect(Collectors.toList());
     }
+
 }

--- a/sources/zafira-ws/src/main/java/com/qaprosoft/zafira/ws/controller/application/SlackAPIController.java
+++ b/sources/zafira-ws/src/main/java/com/qaprosoft/zafira/ws/controller/application/SlackAPIController.java
@@ -15,61 +15,58 @@
  *******************************************************************************/
 package com.qaprosoft.zafira.ws.controller.application;
 
-import java.io.IOException;
-
-import com.qaprosoft.zafira.ws.controller.AbstractController;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
-import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.*;
-
 import com.qaprosoft.zafira.models.db.TestRun;
 import com.qaprosoft.zafira.services.exceptions.ServiceException;
 import com.qaprosoft.zafira.services.services.application.TestRunService;
 import com.qaprosoft.zafira.services.services.application.integration.impl.SlackService;
+import com.qaprosoft.zafira.ws.controller.AbstractController;
 import com.qaprosoft.zafira.ws.swagger.annotations.ResponseStatusDetails;
-
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiImplicitParam;
 import io.swagger.annotations.ApiImplicitParams;
 import io.swagger.annotations.ApiOperation;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
-@Controller
-@Api(value = "Slack API")
+@Api("Slack API")
 @CrossOrigin
-@RequestMapping("api/slack")
-public class SlackAPIController extends AbstractController
-{
+@RequestMapping(path = "api/slack", produces = MediaType.APPLICATION_JSON_VALUE)
+@RestController
+public class SlackAPIController extends AbstractController {
 
-	@Autowired
-	private SlackService slackService;
+    @Autowired
+    private SlackService slackService;
 
-	@Autowired
-	private TestRunService testRunService;
+    @Autowired
+    private TestRunService testRunService;
 
-	@ResponseStatusDetails
-	@ApiOperation(value = "Send notification on testrun review", nickname = "sendReviewNotification", httpMethod = "GET")
-	@ResponseStatus(HttpStatus.OK)
-	@ApiImplicitParams(
-	{ @ApiImplicitParam(name = "Authorization", paramType = "header") })
-	@RequestMapping(value = "testrun/{id}/review", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-	public @ResponseBody void sendOnReviewNotification(@PathVariable(value = "id") long id) throws ServiceException, IOException
-	{
-		TestRun testRun = testRunService.getTestRunByIdFull(id);
-		slackService.sendStatusReviewed(testRun);
-	}
+    @ResponseStatusDetails
+    @ApiOperation(value = "Send notification on testrun review", nickname = "sendReviewNotification", httpMethod = "GET")
+    @ApiImplicitParams({@ApiImplicitParam(name = "Authorization", paramType = "header")})
+    @GetMapping("/testrun/{id}/review")
+    public void sendOnReviewNotification(@PathVariable("id") long id) throws ServiceException {
+        TestRun testRun = testRunService.getTestRunByIdFull(id);
+        slackService.sendStatusReviewed(testRun);
+    }
 
-	@ResponseStatusDetails
-	@ApiOperation(value = "Send notification on testrun finish", nickname = "sendOnFinishNotification", httpMethod = "GET")
-	@ResponseStatus(HttpStatus.OK)
-	@ApiImplicitParams({ @ApiImplicitParam(name = "Authorization", paramType = "header") })
-	@RequestMapping(value = "testrun/{ciRunId}/finish", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-	public @ResponseBody void sendOnFinishNotification(@PathVariable(value = "ciRunId") String ciRunId, @RequestParam(value = "channels", required = false) String channels) throws ServiceException
-	{
-		TestRun testRun = testRunService.getTestRunByCiRunIdFull(ciRunId);
-		testRun.setSlackChannels(channels);
-		testRunService.updateTestRun(testRun);
-		slackService.sendStatusOnFinish(testRun);
-	}
+    @ResponseStatusDetails
+    @ApiOperation(value = "Send notification on testrun finish", nickname = "sendOnFinishNotification", httpMethod = "GET")
+    @ApiImplicitParams({@ApiImplicitParam(name = "Authorization", paramType = "header")})
+    @GetMapping("/testrun/{ciRunId}/finish")
+    public void sendOnFinishNotification(
+            @PathVariable("ciRunId") String ciRunId,
+            @RequestParam(value = "channels", required = false) String channels
+    ) throws ServiceException {
+        TestRun testRun = testRunService.getTestRunByCiRunIdFull(ciRunId);
+        testRun.setSlackChannels(channels);
+        testRunService.updateTestRun(testRun);
+        slackService.sendStatusOnFinish(testRun);
+    }
+
 }

--- a/sources/zafira-ws/src/main/java/com/qaprosoft/zafira/ws/controller/application/StatusAPIController.java
+++ b/sources/zafira-ws/src/main/java/com/qaprosoft/zafira/ws/controller/application/StatusAPIController.java
@@ -15,46 +15,41 @@
  *******************************************************************************/
 package com.qaprosoft.zafira.ws.controller.application;
 
-import org.apache.commons.lang3.StringUtils;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
-import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.ResponseBody;
-import org.springframework.web.bind.annotation.ResponseStatus;
-
 import com.qaprosoft.zafira.services.exceptions.ServiceException;
 import com.qaprosoft.zafira.services.exceptions.UnhealthyStateException;
 import com.qaprosoft.zafira.services.services.application.SettingsService;
 import com.qaprosoft.zafira.ws.controller.AbstractController;
 import com.qaprosoft.zafira.ws.swagger.annotations.ResponseStatusDetails;
-
 import io.swagger.annotations.ApiOperation;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 import springfox.documentation.annotations.ApiIgnore;
 
-@Controller
 @ApiIgnore
-@RequestMapping("api/status")
+@RequestMapping(path = "api/status", produces = MediaType.APPLICATION_JSON_VALUE)
+@RestController
 public class StatusAPIController extends AbstractController {
-	
-	@Autowired
-	private SettingsService settingsService;
 
-	@ResponseStatusDetails
-	@ApiOperation(value = "Get service status", nickname = "status", httpMethod = "GET", response = String.class)
-	@ResponseStatus(HttpStatus.OK)
-	@RequestMapping(method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-	public @ResponseBody String getStatus() throws ServiceException {
-		try {
-			final String version = settingsService.getPostgresVersion();
-			if(StringUtils.isEmpty(version)) {
-				throw new ServiceException("Unable to retrieve Postgres version");
-			}
-		} catch (Exception e) {
-			throw new UnhealthyStateException("Service has no DB connection");
-		}
-		return "Service is up and running";
-	}
+    @Autowired
+    private SettingsService settingsService;
+
+    @ResponseStatusDetails
+    @ApiOperation(value = "Get service status", nickname = "status", httpMethod = "GET", response = String.class)
+    @GetMapping()
+    public String getStatus() throws ServiceException {
+        try {
+            final String version = settingsService.getPostgresVersion();
+            if (StringUtils.isEmpty(version)) {
+                throw new ServiceException("Unable to retrieve Postgres version");
+            }
+        } catch (Exception e) {
+            throw new UnhealthyStateException("Service has no DB connection");
+        }
+        return "Service is up and running";
+    }
+
 }

--- a/sources/zafira-ws/src/main/java/com/qaprosoft/zafira/ws/controller/application/TestSuitesAPIController.java
+++ b/sources/zafira-ws/src/main/java/com/qaprosoft/zafira/ws/controller/application/TestSuitesAPIController.java
@@ -15,53 +15,47 @@
  *******************************************************************************/
 package com.qaprosoft.zafira.ws.controller.application;
 
-import javax.validation.Valid;
-
-import com.qaprosoft.zafira.ws.controller.AbstractController;
-import org.dozer.Mapper;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
-import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.ResponseBody;
-import org.springframework.web.bind.annotation.ResponseStatus;
-
 import com.qaprosoft.zafira.models.db.TestSuite;
 import com.qaprosoft.zafira.models.dto.TestSuiteType;
 import com.qaprosoft.zafira.services.exceptions.ServiceException;
 import com.qaprosoft.zafira.services.services.application.TestSuiteService;
+import com.qaprosoft.zafira.ws.controller.AbstractController;
 import com.qaprosoft.zafira.ws.swagger.annotations.ResponseStatusDetails;
-
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiImplicitParam;
 import io.swagger.annotations.ApiImplicitParams;
 import io.swagger.annotations.ApiOperation;
+import org.dozer.Mapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
-@Controller
-@Api(value = "Test suites operations")
-@RequestMapping("api/tests/suites")
-public class TestSuitesAPIController extends AbstractController
-{
-	@Autowired
-	private Mapper mapper;
+import javax.validation.Valid;
 
-	@Autowired
-	private TestSuiteService testSuiteService;
+@Api("Test suites operations")
+@RequestMapping(path = "api/tests/suites", produces = MediaType.APPLICATION_JSON_VALUE)
+@RestController
+public class TestSuitesAPIController extends AbstractController {
 
-	@ResponseStatusDetails
-	@ApiOperation(value = "Create test suite", nickname = "createTestSuite", httpMethod = "POST", notes = "Create a new test suite.", response = TestSuiteType.class, responseContainer = "TestSuiteType")
-	@ResponseStatus(HttpStatus.OK)
-	@ApiImplicitParams(
-	{ @ApiImplicitParam(name = "Authorization", paramType = "header") })
-	@RequestMapping(method = RequestMethod.POST, produces = MediaType.APPLICATION_JSON_VALUE)
-	public @ResponseBody TestSuiteType createTestSuite(@RequestBody @Valid TestSuiteType testSuite,
-			@RequestHeader(value = "Project", required = false) String project) throws ServiceException
-	{
-		return mapper.map(testSuiteService.createOrUpdateTestSuite(mapper.map(testSuite, TestSuite.class)),
-				TestSuiteType.class);
-	}
+    @Autowired
+    private Mapper mapper;
+
+    @Autowired
+    private TestSuiteService testSuiteService;
+
+    @ResponseStatusDetails
+    @ApiOperation(value = "Create test suite", nickname = "createTestSuite", httpMethod = "POST", notes = "Create a new test suite.", response = TestSuiteType.class, responseContainer = "TestSuiteType")
+    @ApiImplicitParams({@ApiImplicitParam(name = "Authorization", paramType = "header")})
+    @PostMapping()
+    public TestSuiteType createTestSuite(
+            @RequestBody @Valid TestSuiteType testSuite,
+            @RequestHeader(value = "Project", required = false) String project
+    ) throws ServiceException {
+        return mapper.map(testSuiteService.createOrUpdateTestSuite(mapper.map(testSuite, TestSuite.class)), TestSuiteType.class);
+    }
+
 }

--- a/sources/zafira-ws/src/main/java/com/qaprosoft/zafira/ws/controller/application/TestsAPIController.java
+++ b/sources/zafira-ws/src/main/java/com/qaprosoft/zafira/ws/controller/application/TestsAPIController.java
@@ -15,32 +15,13 @@
  *******************************************************************************/
 package com.qaprosoft.zafira.ws.controller.application;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import javax.validation.Valid;
-
-import com.qaprosoft.zafira.models.db.*;
-import com.qaprosoft.zafira.services.exceptions.ForbiddenOperationException;
-import com.qaprosoft.zafira.services.services.application.cache.StatisticsService;
-import com.qaprosoft.zafira.ws.controller.AbstractController;
-import org.dozer.Mapper;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
-import org.springframework.messaging.simp.SimpMessagingTemplate;
-import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.ResponseBody;
-import org.springframework.web.bind.annotation.ResponseStatus;
-
 import com.qaprosoft.zafira.dbaccess.dao.mysql.application.search.SearchResult;
 import com.qaprosoft.zafira.dbaccess.dao.mysql.application.search.TestSearchCriteria;
+import com.qaprosoft.zafira.models.db.Test;
+import com.qaprosoft.zafira.models.db.TestArtifact;
+import com.qaprosoft.zafira.models.db.TestRun;
+import com.qaprosoft.zafira.models.db.User;
+import com.qaprosoft.zafira.models.db.WorkItem;
 import com.qaprosoft.zafira.models.db.WorkItem.Type;
 import com.qaprosoft.zafira.models.dto.TestArtifactType;
 import com.qaprosoft.zafira.models.dto.TestRunStatistics;
@@ -48,262 +29,260 @@ import com.qaprosoft.zafira.models.dto.TestType;
 import com.qaprosoft.zafira.models.push.TestPush;
 import com.qaprosoft.zafira.models.push.TestRunPush;
 import com.qaprosoft.zafira.models.push.TestRunStatisticPush;
+import com.qaprosoft.zafira.services.exceptions.ForbiddenOperationException;
 import com.qaprosoft.zafira.services.exceptions.ServiceException;
 import com.qaprosoft.zafira.services.services.application.TestArtifactService;
 import com.qaprosoft.zafira.services.services.application.TestMetricService;
 import com.qaprosoft.zafira.services.services.application.TestRunService;
 import com.qaprosoft.zafira.services.services.application.TestService;
 import com.qaprosoft.zafira.services.services.application.WorkItemService;
+import com.qaprosoft.zafira.services.services.application.cache.StatisticsService;
 import com.qaprosoft.zafira.services.services.application.integration.impl.JiraService;
+import com.qaprosoft.zafira.ws.controller.AbstractController;
 import com.qaprosoft.zafira.ws.swagger.annotations.ResponseStatusDetails;
-
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiImplicitParam;
 import io.swagger.annotations.ApiImplicitParams;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import net.rcarz.jiraclient.Issue;
+import org.dozer.Mapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 import springfox.documentation.annotations.ApiIgnore;
 
-@Controller
-@Api(value = "Tests API")
-@RequestMapping("api/tests")
-public class TestsAPIController extends AbstractController
-{
-	@Autowired
-	private Mapper mapper;
+import javax.validation.Valid;
+import java.util.ArrayList;
+import java.util.List;
 
-	@Autowired
-	private TestService testService;
-	
-	@Autowired
-	private TestArtifactService testArtifactService;
+@Api("Tests API")
+@RequestMapping(path = "api/tests", produces = MediaType.APPLICATION_JSON_VALUE)
+@RestController
+public class TestsAPIController extends AbstractController {
 
-	@Autowired
-	private TestMetricService testMetricService;
+    @Autowired
+    private Mapper mapper;
 
-	@Autowired
-	private TestRunService testRunService;
+    @Autowired
+    private TestService testService;
 
-	@Autowired
-	private WorkItemService workItemService;
+    @Autowired
+    private TestArtifactService testArtifactService;
 
-	@Autowired
-	private JiraService jiraService;
+    @Autowired
+    private TestMetricService testMetricService;
 
-	@Autowired
-	private SimpMessagingTemplate websocketTemplate;
+    @Autowired
+    private TestRunService testRunService;
 
-	@Autowired
-	private StatisticsService statisticsService;
+    @Autowired
+    private WorkItemService workItemService;
 
-	@ResponseStatusDetails
-	@ApiOperation(value = "Start test", nickname = "startTest", httpMethod = "POST", response = TestType.class)
-	@ResponseStatus(HttpStatus.OK)
-	@ApiImplicitParams(
-	{ @ApiImplicitParam(name = "Authorization", paramType = "header") })
-	@RequestMapping(method = RequestMethod.POST, produces = MediaType.APPLICATION_JSON_VALUE)
-	public @ResponseBody TestType startTest(@Valid @RequestBody TestType t,
-			@RequestHeader(value = "Project", required = false) String project) throws ServiceException
-	{
-		Test test = testService.startTest(mapper.map(t, Test.class), t.getWorkItems(), t.getConfigXML());
-		websocketTemplate.convertAndSend(getStatisticsWebsocketPath(), new TestRunStatisticPush(statisticsService.getTestRunStatistic(test.getTestRunId())));
-		websocketTemplate.convertAndSend(getTestsWebsocketPath(test.getTestRunId()), new TestPush(test));
-		return mapper.map(test, TestType.class);
-	}
+    @Autowired
+    private JiraService jiraService;
 
-	@ResponseStatusDetails
-	@ApiOperation(value = "Finish test", nickname = "finishTest", httpMethod = "POST", response = TestType.class)
-	@ResponseStatus(HttpStatus.OK)
-	@ApiImplicitParams(
-	{ @ApiImplicitParam(name = "Authorization", paramType = "header") })
-	@RequestMapping(value = "{id}/finish", method = RequestMethod.POST)
-	public @ResponseBody TestType finishTest(
-			@ApiParam(value = "Test ID", required = true) @PathVariable(value = "id") long id, @RequestBody TestType t)
-			throws ServiceException
-	{
-		t.setId(id);
-		Test test = testService.finishTest(mapper.map(t, Test.class), t.getConfigXML());
-		testService.deleteQueuedTest(test);
-		testMetricService.createTestMetrics(t.getId(), t.getTestMetrics());
-		websocketTemplate.convertAndSend(getStatisticsWebsocketPath(), new TestRunStatisticPush(statisticsService.getTestRunStatistic(test.getTestRunId())));
-		websocketTemplate.convertAndSend(getTestsWebsocketPath(test.getTestRunId()), new TestPush(test));
-		return mapper.map(test, TestType.class);
-	}
+    @Autowired
+    private SimpMessagingTemplate websocketTemplate;
 
-	@ResponseStatusDetails
-	@ApiOperation(value = "Update test", nickname = "updateTest", httpMethod = "PUT", response = Test.class)
-	@ResponseStatus(HttpStatus.OK)
-	@ApiImplicitParams(
-			{ @ApiImplicitParam(name = "Authorization", paramType = "header") })
-	@PreAuthorize("hasPermission('MODIFY_TESTS')")
-	@RequestMapping(method = RequestMethod.PUT, produces = MediaType.APPLICATION_JSON_VALUE)
-	public @ResponseBody Test updateTest(@RequestBody Test test) throws ServiceException, InterruptedException
-	{
-		Test updatedTest = testService.changeTestStatus(test.getId(), test.getStatus());
+    @Autowired
+    private StatisticsService statisticsService;
 
-		websocketTemplate.convertAndSend(getStatisticsWebsocketPath(), new TestRunStatisticPush(statisticsService.getTestRunStatistic(updatedTest.getTestRunId())));
-		websocketTemplate.convertAndSend(getTestsWebsocketPath(updatedTest.getTestRunId()), new TestPush(updatedTest));
-		TestRun testRun = testRunService.getTestRunById(updatedTest.getTestRunId());
-		websocketTemplate.convertAndSend(getTestRunsWebsocketPath(), new TestRunPush(testRun));
-		return updatedTest;
-	}
+    @ResponseStatusDetails
+    @ApiOperation(value = "Start test", nickname = "startTest", httpMethod = "POST", response = TestType.class)
+    @ApiImplicitParams({@ApiImplicitParam(name = "Authorization", paramType = "header")})
+    @PostMapping()
+    public TestType startTest(@Valid @RequestBody TestType t, @RequestHeader(value = "Project", required = false) String project) throws ServiceException {
+        Test test = testService.startTest(mapper.map(t, Test.class), t.getWorkItems(), t.getConfigXML());
+        websocketTemplate.convertAndSend(
+                getStatisticsWebsocketPath(),
+                new TestRunStatisticPush(statisticsService.getTestRunStatistic(test.getTestRunId()))
+        );
+        websocketTemplate.convertAndSend(getTestsWebsocketPath(test.getTestRunId()), new TestPush(test));
+        return mapper.map(test, TestType.class);
+    }
 
-	@ResponseStatusDetails
-	@ApiOperation(value = "Create test work items", nickname = "createTestWorkItems", httpMethod = "POST", response = TestType.class)
-	@ResponseStatus(HttpStatus.OK)
-	@ApiImplicitParams(
-	{ @ApiImplicitParam(name = "Authorization", paramType = "header") })
-	@RequestMapping(value = "{id}/workitems", method = RequestMethod.POST, produces = MediaType.APPLICATION_JSON_VALUE)
-	public @ResponseBody TestType createTestWorkItems(
-			@ApiParam(value = "Work item ID", required = true) @PathVariable(value = "id") long id,
-			@RequestBody List<String> workItems) throws ServiceException
-	{
-		return mapper.map(testService.createTestWorkItems(id, workItems), TestType.class);
-	}
+    @ResponseStatusDetails
+    @ApiOperation(value = "Finish test", nickname = "finishTest", httpMethod = "POST", response = TestType.class)
+    @ApiImplicitParams({@ApiImplicitParam(name = "Authorization", paramType = "header")})
+    @PostMapping("/{id}/finish")
+    public TestType finishTest(@ApiParam(value = "Test ID", required = true) @PathVariable("id") long id, @RequestBody TestType t) throws ServiceException {
+        t.setId(id);
+        Test test = testService.finishTest(mapper.map(t, Test.class), t.getConfigXML());
+        testService.deleteQueuedTest(test);
+        testMetricService.createTestMetrics(t.getId(), t.getTestMetrics());
+        websocketTemplate.convertAndSend(
+                getStatisticsWebsocketPath(),
+                new TestRunStatisticPush(statisticsService.getTestRunStatistic(test.getTestRunId()))
+        );
+        websocketTemplate.convertAndSend(getTestsWebsocketPath(test.getTestRunId()), new TestPush(test));
+        return mapper.map(test, TestType.class);
+    }
 
-	@ResponseStatusDetails
-	@ApiOperation(value = "Delete test by id", nickname = "deleteTest", httpMethod = "DELETE")
-	@ResponseStatus(HttpStatus.OK)
-	@ApiImplicitParams(
-	{ @ApiImplicitParam(name = "Authorization", paramType = "header") })
-	@RequestMapping(value = "{id}", method = RequestMethod.DELETE)
-	public void deleteTest(@ApiParam(value = "Test ID", required = true) @PathVariable(value = "id") long id)
-			throws ServiceException
-	{
-		testService.deleteTestById(id);
-	}
+    @ResponseStatusDetails
+    @ApiOperation(value = "Update test", nickname = "updateTest", httpMethod = "PUT", response = Test.class)
+    @ApiImplicitParams({@ApiImplicitParam(name = "Authorization", paramType = "header")})
+    @PreAuthorize("hasPermission('MODIFY_TESTS')")
+    @PutMapping()
+    public Test updateTest(@RequestBody Test test) throws ServiceException, InterruptedException {
+        Test updatedTest = testService.changeTestStatus(test.getId(), test.getStatus());
 
-	@ResponseStatusDetails
-	@ApiOperation(value = "Search tests", nickname = "searchTests", httpMethod = "POST", response = SearchResult.class)
-	@ResponseStatus(HttpStatus.OK)
-	@ApiImplicitParams(
-	{ @ApiImplicitParam(name = "Authorization", paramType = "header") })
-	@RequestMapping(value = "search", method = RequestMethod.POST, produces = MediaType.APPLICATION_JSON_VALUE)
-	public @ResponseBody SearchResult<Test> searchTests(@RequestBody TestSearchCriteria sc) throws ServiceException
-	{
-		return testService.searchTests(sc);
-	}
+        websocketTemplate.convertAndSend(getStatisticsWebsocketPath(), new TestRunStatisticPush(statisticsService
+                .getTestRunStatistic(updatedTest.getTestRunId())));
+        websocketTemplate.convertAndSend(getTestsWebsocketPath(updatedTest.getTestRunId()), new TestPush(updatedTest));
+        TestRun testRun = testRunService.getTestRunById(updatedTest.getTestRunId());
+        websocketTemplate.convertAndSend(getTestRunsWebsocketPath(), new TestRunPush(testRun));
+        return updatedTest;
+    }
 
-	@ResponseStatusDetails
-	@ApiOperation(value = "Get test case work items by type", nickname = "getTestCaseWorkItemsByType", httpMethod = "GET", response = List.class)
-	@ResponseStatus(HttpStatus.OK)
-	@ApiImplicitParams(
-	{ @ApiImplicitParam(name = "Authorization", paramType = "header") })
-	@RequestMapping(value = "{id}/workitem/{type}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-	public @ResponseBody List<WorkItem> getTestCaseWorkItemsByType(
-			@ApiParam(value = "Test ID", required = true) @PathVariable(value = "id") long id,  @PathVariable(value = "type") String type) throws ServiceException
-	{
-		List<WorkItem> workItems = new ArrayList<>();
-		Test test = testService.getTestById(id);
-		if (test != null)
-		{
-			workItems = workItemService.getWorkItemsByTestCaseIdAndType(test.getTestCaseId(), Type.valueOf(type));
-		}
-		return workItems;
-	}
+    @ResponseStatusDetails
+    @ApiOperation(value = "Create test work items", nickname = "createTestWorkItems", httpMethod = "POST", response = TestType.class)
+    @ApiImplicitParams({@ApiImplicitParam(name = "Authorization", paramType = "header")})
+    @PostMapping("/{id}/workitems")
+    public TestType createTestWorkItems(
+            @ApiParam(value = "Work item ID", required = true) @PathVariable("id") long id,
+            @RequestBody List<String> workItems
+    ) throws ServiceException {
+        return mapper.map(testService.createTestWorkItems(id, workItems), TestType.class);
+    }
 
-	@ResponseStatusDetails
-	@ApiOperation(value = "Create or update test work item", nickname = "createOrUpdateTestWorkItem", httpMethod = "POST", response = WorkItem.class)
-	@ResponseStatus(HttpStatus.OK)
-	@ApiImplicitParams(
-	{ @ApiImplicitParam(name = "Authorization", paramType = "header") })
-	@RequestMapping(value = "{id}/workitem", method = RequestMethod.POST, produces = MediaType.APPLICATION_JSON_VALUE)
-	public @ResponseBody WorkItem createOrUpdateTestWorkItem(
-			@ApiParam(value = "Test ID", required = true) @PathVariable(value = "id") long id,
-			@RequestBody WorkItem workItem) throws ServiceException, InterruptedException
-	{
-		if (getPrincipalId() > 0) {
-			workItem.setUser(new User(getPrincipalId()));
-		}
-		if (workItem.getType() == Type.BUG || workItem.getType() == Type.TASK) {
-			workItem = testService.createOrUpdateTestWorkItem(id, workItem);
-		} else  {
-			workItem = testService.createWorkItem(id, workItem);
-		}
-		Test test = testService.getTestById(id);
+    @ResponseStatusDetails
+    @ApiOperation(value = "Delete test by id", nickname = "deleteTest", httpMethod = "DELETE")
+    @ApiImplicitParams({@ApiImplicitParam(name = "Authorization", paramType = "header")})
+    @DeleteMapping("/{id}")
+    public void deleteTest(@ApiParam(value = "Test ID", required = true) @PathVariable("id") long id) throws ServiceException {
+        testService.deleteTestById(id);
+    }
 
-		websocketTemplate.convertAndSend(getStatisticsWebsocketPath(), new TestRunStatisticPush(statisticsService.getTestRunStatistic(test.getTestRunId())));
-		websocketTemplate.convertAndSend(getTestsWebsocketPath(test.getTestRunId()), new TestPush(test));
-		
-		TestRun testRun = testRunService.getTestRunById(test.getTestRunId());
-		websocketTemplate.convertAndSend(getTestRunsWebsocketPath(), new TestRunPush(testRun));
+    @ResponseStatusDetails
+    @ApiOperation(value = "Search tests", nickname = "searchTests", httpMethod = "POST", response = SearchResult.class)
+    @ApiImplicitParams({@ApiImplicitParam(name = "Authorization", paramType = "header")})
+    @PostMapping("/search")
+    public SearchResult<Test> searchTests(@RequestBody TestSearchCriteria sc) throws ServiceException {
+        return testService.searchTests(sc);
+    }
 
-		return workItem;
-	}
+    @ResponseStatusDetails
+    @ApiOperation(value = "Get test case work items by type", nickname = "getTestCaseWorkItemsByType", httpMethod = "GET", response = List.class)
+    @ApiImplicitParams({@ApiImplicitParam(name = "Authorization", paramType = "header")})
+    @GetMapping("/{id}/workitem/{type}")
+    public List<WorkItem> getTestCaseWorkItemsByType(
+            @ApiParam(value = "Test ID", required = true)
+            @PathVariable("id") long id,
+            @PathVariable("type") String type
+    ) throws ServiceException {
+        List<WorkItem> workItems = new ArrayList<>();
+        Test test = testService.getTestById(id);
+        if (test != null) {
+            workItems = workItemService.getWorkItemsByTestCaseIdAndType(test.getTestCaseId(), Type.valueOf(type));
+        }
+        return workItems;
+    }
 
-	@ResponseStatusDetails
-	@ApiOperation(value = "Update test known issue", nickname = "updateTestKnownIssue", httpMethod = "PUT", response = WorkItem.class)
-	@ResponseStatus(HttpStatus.OK)
-	@ApiImplicitParams(
-	{ @ApiImplicitParam(name = "Authorization", paramType = "header") })
-	@RequestMapping(value = "{id}/issues", method = RequestMethod.PUT, produces = MediaType.APPLICATION_JSON_VALUE)
-	public @ResponseBody WorkItem updateTestKnownIssue(
-			@ApiParam(value = "Test ID", required = true) @PathVariable(value = "id") long id,
-			@RequestBody WorkItem workItem) throws ServiceException
-	{
-		Test test = testService.getTestById(id);
-		workItem.setHashCode(testService.getTestMessageHashCode(test.getMessage()));
-		return workItemService.updateWorkItem(workItem);
-	}
+    @ResponseStatusDetails
+    @ApiOperation(value = "Create or update test work item", nickname = "createOrUpdateTestWorkItem", httpMethod = "POST", response = WorkItem.class)
+    @ApiImplicitParams({@ApiImplicitParam(name = "Authorization", paramType = "header")})
+    @PostMapping("/{id}/workitem")
+    public WorkItem createOrUpdateTestWorkItem(
+            @ApiParam(value = "Test ID", required = true) @PathVariable("id") long id,
+            @RequestBody WorkItem workItem
+    ) throws ServiceException, InterruptedException {
+        if (getPrincipalId() > 0) {
+            workItem.setUser(new User(getPrincipalId()));
+        }
+        if (workItem.getType() == Type.BUG || workItem.getType() == Type.TASK) {
+            workItem = testService.createOrUpdateTestWorkItem(id, workItem);
+        } else {
+            workItem = testService.createWorkItem(id, workItem);
+        }
+        Test test = testService.getTestById(id);
 
-	@ResponseStatusDetails
-	@ApiOperation(value = "Delete test work item", nickname = "deleteTestWorkItem", httpMethod = "DELETE")
-	@ResponseStatus(HttpStatus.OK)
-	@ApiImplicitParams(
-			{ @ApiImplicitParam(name = "Authorization", paramType = "header") })
-	@RequestMapping(value = "{testId}/workitem/{workItemId}", method = RequestMethod.DELETE)
-	public void deleteTestWorkItem(@PathVariable(value = "workItemId") long workItemId,
-			@PathVariable(value = "testId") long testId) throws ServiceException, InterruptedException
-	{
-		Test test = testService.getTestById(testId);
-		WorkItem workItem = workItemService.getWorkItemById(workItemId);
-		if (workItem.getType() == Type.BUG) {
-			testRunService.updateStatistics(test.getTestRunId(), TestRunStatistics.Action.REMOVE_KNOWN_ISSUE);
-			if (test.isBlocker())
-				testRunService.updateStatistics(test.getTestRunId(), TestRunStatistics.Action.REMOVE_BLOCKER);
-			websocketTemplate.convertAndSend(getStatisticsWebsocketPath(),
-					new TestRunStatisticPush(statisticsService.getTestRunStatistic(test.getTestRunId())));
-			websocketTemplate.convertAndSend(getTestsWebsocketPath(test.getTestRunId()), new TestPush(test));
-			TestRun testRun = testRunService.getTestRunById(test.getTestRunId());
-			websocketTemplate.convertAndSend(getTestRunsWebsocketPath(), new TestRunPush(testRun));
-		}
-		testService.deleteTestWorkItemByWorkItemIdAndTest(workItemId, test);
-	}
+        websocketTemplate.convertAndSend(getStatisticsWebsocketPath(), new TestRunStatisticPush(statisticsService
+                .getTestRunStatistic(test.getTestRunId())));
+        websocketTemplate.convertAndSend(getTestsWebsocketPath(test.getTestRunId()), new TestPush(test));
 
-	@ApiIgnore
-	@ResponseStatus(HttpStatus.OK)
-	@ApiImplicitParams(
-	{ @ApiImplicitParam(name = "Authorization", paramType = "header") })
-	@RequestMapping(value = "jira/{issue}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-	public @ResponseBody Issue getJiraIssue(@PathVariable(value = "issue") String issue)
-	{
-		return jiraService.getIssue(issue).orElseThrow(() -> new ForbiddenOperationException("Unable to retrieve jira issue"));
-	}
+        TestRun testRun = testRunService.getTestRunById(test.getTestRunId());
+        websocketTemplate.convertAndSend(getTestRunsWebsocketPath(), new TestRunPush(testRun));
 
-	@ApiIgnore
-	@ResponseStatus(HttpStatus.OK)
-	@ApiImplicitParams(
-	{ @ApiImplicitParam(name = "Authorization", paramType = "header") })
-	@RequestMapping(value = "jira/connect", method = RequestMethod.GET)
-	public @ResponseBody boolean getConnectionToJira()
-	{
-		return jiraService.isEnabledAndConnected();
-	}
-	
-	@ResponseStatusDetails
-	@ApiOperation(value = "Add test artifact", nickname = "addTestArtifact", httpMethod = "POST")
-	@ResponseStatus(HttpStatus.OK)
-	@ApiImplicitParams(
-	{ @ApiImplicitParam(name = "Authorization", paramType = "header") })
-	@RequestMapping(value = "{id}/artifacts", method = RequestMethod.POST)
-	public void addTestArtifact(@ApiParam(value = "Test ID", required = true) @PathVariable(value = "id") long id, @RequestBody TestArtifactType artifact)
-			throws ServiceException
-	{
-		artifact.setTestId(id);
-		testArtifactService.createOrUpdateTestArtifact(mapper.map(artifact, TestArtifact.class));
-		// Updating web client with latest artifacts
-		Test test = testService.getTestById(id);
-		websocketTemplate.convertAndSend(getTestsWebsocketPath(test.getTestRunId()), new TestPush(test));
-	}
+        return workItem;
+    }
+
+    @ResponseStatusDetails
+    @ApiOperation(value = "Update test known issue", nickname = "updateTestKnownIssue", httpMethod = "PUT", response = WorkItem.class)
+    @ApiImplicitParams({@ApiImplicitParam(name = "Authorization", paramType = "header")})
+    @PutMapping("/{id}/issues")
+    public WorkItem updateTestKnownIssue(
+            @ApiParam(value = "Test ID", required = true) @PathVariable("id") long id,
+            @RequestBody WorkItem workItem
+    ) throws ServiceException {
+        Test test = testService.getTestById(id);
+        workItem.setHashCode(testService.getTestMessageHashCode(test.getMessage()));
+        return workItemService.updateWorkItem(workItem);
+    }
+
+    @ResponseStatusDetails
+    @ApiOperation(value = "Delete test work item", nickname = "deleteTestWorkItem", httpMethod = "DELETE")
+    @ApiImplicitParams({@ApiImplicitParam(name = "Authorization", paramType = "header")})
+    @DeleteMapping("/{testId}/workitem/{workItemId}")
+    public void deleteTestWorkItem(
+            @PathVariable("workItemId") long workItemId,
+            @PathVariable("testId") long testId
+    ) throws ServiceException, InterruptedException {
+        Test test = testService.getTestById(testId);
+        WorkItem workItem = workItemService.getWorkItemById(workItemId);
+        if (workItem.getType() == Type.BUG) {
+            testRunService.updateStatistics(test.getTestRunId(), TestRunStatistics.Action.REMOVE_KNOWN_ISSUE);
+            if (test.isBlocker()) {
+                testRunService.updateStatistics(test.getTestRunId(), TestRunStatistics.Action.REMOVE_BLOCKER);
+            }
+            websocketTemplate.convertAndSend(getStatisticsWebsocketPath(),
+                    new TestRunStatisticPush(statisticsService.getTestRunStatistic(test.getTestRunId())));
+            websocketTemplate.convertAndSend(getTestsWebsocketPath(test.getTestRunId()), new TestPush(test));
+            TestRun testRun = testRunService.getTestRunById(test.getTestRunId());
+            websocketTemplate.convertAndSend(getTestRunsWebsocketPath(), new TestRunPush(testRun));
+        }
+        testService.deleteTestWorkItemByWorkItemIdAndTest(workItemId, test);
+    }
+
+    @ApiIgnore
+    @ApiImplicitParams({@ApiImplicitParam(name = "Authorization", paramType = "header")})
+    @GetMapping("/jira/{issue}")
+    public Issue getJiraIssue(@PathVariable("issue") String issue) {
+        return jiraService.getIssue(issue)
+                          .orElseThrow(() -> new ForbiddenOperationException("Unable to retrieve jira issue"));
+    }
+
+    @ApiIgnore
+    @ApiImplicitParams({@ApiImplicitParam(name = "Authorization", paramType = "header")})
+    @GetMapping("/jira/connect")
+    public boolean getConnectionToJira() {
+        return jiraService.isEnabledAndConnected();
+    }
+
+    @ResponseStatusDetails
+    @ApiOperation(value = "Add test artifact", nickname = "addTestArtifact", httpMethod = "POST")
+    @ApiImplicitParams({@ApiImplicitParam(name = "Authorization", paramType = "header")})
+    @PostMapping("/{id}/artifacts")
+    public void addTestArtifact(
+            @ApiParam(value = "Test ID", required = true)
+            @PathVariable("id") long id,
+            @RequestBody TestArtifactType artifact
+    ) throws ServiceException {
+        artifact.setTestId(id);
+        testArtifactService.createOrUpdateTestArtifact(mapper.map(artifact, TestArtifact.class));
+        // Updating web client with latest artifacts
+        Test test = testService.getTestById(id);
+        websocketTemplate.convertAndSend(getTestsWebsocketPath(test.getTestRunId()), new TestPush(test));
+    }
+
 }

--- a/sources/zafira-ws/src/main/java/com/qaprosoft/zafira/ws/controller/application/UsersAPIController.java
+++ b/sources/zafira-ws/src/main/java/com/qaprosoft/zafira/ws/controller/application/UsersAPIController.java
@@ -15,258 +15,221 @@
  *******************************************************************************/
 package com.qaprosoft.zafira.ws.controller.application;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import javax.validation.Valid;
-
-import com.qaprosoft.zafira.models.dto.user.PasswordChangingType;
-import com.qaprosoft.zafira.services.services.application.DashboardService;
-import com.qaprosoft.zafira.services.services.application.integration.impl.AmazonService;
-import com.qaprosoft.zafira.ws.controller.AbstractController;
-import org.apache.commons.lang3.StringUtils;
-import org.dozer.Mapper;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
-import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.CrossOrigin;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.ResponseBody;
-import org.springframework.web.bind.annotation.ResponseStatus;
-
 import com.qaprosoft.zafira.dbaccess.dao.mysql.application.search.SearchResult;
 import com.qaprosoft.zafira.dbaccess.dao.mysql.application.search.UserSearchCriteria;
 import com.qaprosoft.zafira.models.db.User;
 import com.qaprosoft.zafira.models.db.UserPreference;
+import com.qaprosoft.zafira.models.dto.user.PasswordChangingType;
 import com.qaprosoft.zafira.models.dto.user.UserType;
 import com.qaprosoft.zafira.services.exceptions.ServiceException;
 import com.qaprosoft.zafira.services.exceptions.UserNotFoundException;
+import com.qaprosoft.zafira.services.services.application.DashboardService;
 import com.qaprosoft.zafira.services.services.application.UserPreferenceService;
 import com.qaprosoft.zafira.services.services.application.UserService;
+import com.qaprosoft.zafira.services.services.application.integration.impl.AmazonService;
+import com.qaprosoft.zafira.ws.controller.AbstractController;
 import com.qaprosoft.zafira.ws.swagger.annotations.ResponseStatusDetails;
-
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiImplicitParam;
 import io.swagger.annotations.ApiImplicitParams;
 import io.swagger.annotations.ApiOperation;
+import org.apache.commons.lang3.StringUtils;
+import org.dozer.Mapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
-@Controller
-@Api(value = "Users API")
+import javax.validation.Valid;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Api("Users API")
 @CrossOrigin
-@RequestMapping("api/users")
-public class UsersAPIController extends AbstractController
-{
-	@Autowired
-	private UserService userService;
+@RequestMapping(path = "api/users", produces = MediaType.APPLICATION_JSON_VALUE)
+@RestController
+public class UsersAPIController extends AbstractController {
 
-	@Autowired
-	DashboardService dashboardService;
+    @Autowired
+    private UserService userService;
 
-	@Autowired
-	private UserPreferenceService userPreferenceService;
+    @Autowired
+    DashboardService dashboardService;
 
-	@Autowired
-	private AmazonService amazonService;
+    @Autowired
+    private UserPreferenceService userPreferenceService;
 
-	@Autowired
-	private Mapper mapper;
+    @Autowired
+    private AmazonService amazonService;
 
-	@ResponseStatusDetails
-	@ApiOperation(value = "Get user profile", nickname = "getUserProfile", httpMethod = "GET", response = UserType.class)
-	@ResponseStatus(HttpStatus.OK)
-	@ApiImplicitParams(
-	{ @ApiImplicitParam(name = "Authorization", paramType = "header") })
-	@RequestMapping(value = "profile", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-	public @ResponseBody UserType getUserProfile(@RequestParam(value = "username", required=false) String username) throws ServiceException
-	{
-		User user = StringUtils.isEmpty(username) ? userService.getUserById(getPrincipalId()) : userService.getUserByUsername(username);
-		if(user == null) 
-		{
-			throw new UserNotFoundException();
-		}
-		UserType userType = mapper.map(user, UserType.class);
-		userType.setRoles(user.getRoles());
-		userType.setPreferences(user.getPreferences());
-		userType.setPermissions(user.getPermissions());
-		return userType;
-	}
+    @Autowired
+    private Mapper mapper;
 
-	@ResponseStatusDetails
-	@ApiOperation(value = "Get extended user profile", nickname = "getExtendedUserProfile", httpMethod = "GET", response = Map.class)
-	@ResponseStatus(HttpStatus.OK)
-	@ApiImplicitParams(
-			{ @ApiImplicitParam(name = "Authorization", paramType = "header") })
-	@RequestMapping(value = "profile/extended", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-	public @ResponseBody Map<String, Object> getExtendedUserProfile() throws ServiceException
-	{
-		Map<String, Object> extendedUserProfile = new HashMap<>();
-		User user = userService.getUserById(getPrincipalId());
-		UserType userType = mapper.map(user, UserType.class);
-		userType.setRoles(user.getRoles());
-		userType.setPreferences(user.getPreferences());
-		userType.setPermissions(user.getPermissions());
-		extendedUserProfile.put("user", userType);
-		dashboardService.setDefaultDashboard(extendedUserProfile, "", "defaultDashboardId");
-		dashboardService.setDefaultDashboard(extendedUserProfile, "User Performance", "performanceDashboardId");
-		dashboardService.setDefaultDashboard(extendedUserProfile, "Personal", "personalDashboardId");
-		dashboardService.setDefaultDashboard(extendedUserProfile, "Stability", "stabilityDashboardId");
-		return extendedUserProfile;
-	}
+    @ResponseStatusDetails
+    @ApiOperation(value = "Get user profile", nickname = "getUserProfile", httpMethod = "GET", response = UserType.class)
+    @ApiImplicitParams({@ApiImplicitParam(name = "Authorization", paramType = "header")})
+    @GetMapping("/profile")
+    public UserType getUserProfile(@RequestParam(value = "username", required = false) String username) throws ServiceException {
+        User user = StringUtils.isEmpty(username) ? userService.getUserById(getPrincipalId())
+                                                  : userService.getUserByUsername(username);
+        if (user == null) {
+            throw new UserNotFoundException();
+        }
+        UserType userType = mapper.map(user, UserType.class);
+        userType.setRoles(user.getRoles());
+        userType.setPreferences(user.getPreferences());
+        userType.setPermissions(user.getPermissions());
+        return userType;
+    }
 
-	@ResponseStatusDetails
-	@ApiOperation(value = "Update user profile", nickname = "updateUserProfile", httpMethod = "PUT", response = UserType.class)
-	@ResponseStatus(HttpStatus.OK)
-	@ApiImplicitParams(
-	{ @ApiImplicitParam(name = "Authorization", paramType = "header") })
-	@RequestMapping(value = "profile", method = RequestMethod.PUT, produces = MediaType.APPLICATION_JSON_VALUE)
-	public @ResponseBody UserType updateUserProfile(@Valid @RequestBody UserType user) throws ServiceException
-	{
-		checkCurrentUserAccess(user.getId());
-		UserType userType =  mapper.map(userService.updateUser(mapper.map(user, User.class)), UserType.class);
-		userType.setRoles(user.getRoles());
-		userType.setPreferences(user.getPreferences());
-		userType.setPhotoURL(user.getPhotoURL());
-		return userType;
-	}
+    @ResponseStatusDetails
+    @ApiOperation(value = "Get extended user profile", nickname = "getExtendedUserProfile", httpMethod = "GET", response = Map.class)
+    @ApiImplicitParams({@ApiImplicitParam(name = "Authorization", paramType = "header")})
+    @GetMapping("/profile/extended")
+    public Map<String, Object> getExtendedUserProfile() throws ServiceException {
+        Map<String, Object> extendedUserProfile = new HashMap<>();
+        User user = userService.getUserById(getPrincipalId());
+        UserType userType = mapper.map(user, UserType.class);
+        userType.setRoles(user.getRoles());
+        userType.setPreferences(user.getPreferences());
+        userType.setPermissions(user.getPermissions());
+        extendedUserProfile.put("user", userType);
+        dashboardService.setDefaultDashboard(extendedUserProfile, "", "defaultDashboardId");
+        dashboardService.setDefaultDashboard(extendedUserProfile, "User Performance", "performanceDashboardId");
+        dashboardService.setDefaultDashboard(extendedUserProfile, "Personal", "personalDashboardId");
+        dashboardService.setDefaultDashboard(extendedUserProfile, "Stability", "stabilityDashboardId");
+        return extendedUserProfile;
+    }
 
-	@ResponseStatusDetails
-	@ApiOperation(value = "Delete user profile photo", nickname = "deleteUserProfilePhoto", httpMethod = "DELETE")
-	@ResponseStatus(HttpStatus.OK)
-	@ApiImplicitParams(
-			{ @ApiImplicitParam(name = "Authorization", paramType = "header") })
-	@RequestMapping(value = "profile/photo", method = RequestMethod.DELETE)
-	public void deleteUserProfilePhoto() throws ServiceException
-	{
-		User user = userService.getUserById(getPrincipalId());
-		amazonService.removeFile(user.getPhotoURL());
-		user.setPhotoURL(StringUtils.EMPTY);
-		userService.updateUser(user);
-	}
+    @ResponseStatusDetails
+    @ApiOperation(value = "Update user profile", nickname = "updateUserProfile", httpMethod = "PUT", response = UserType.class)
+    @ApiImplicitParams({@ApiImplicitParam(name = "Authorization", paramType = "header")})
+    @PutMapping("/profile")
+    public UserType updateUserProfile(@Valid @RequestBody UserType user) throws ServiceException {
+        checkCurrentUserAccess(user.getId());
+        UserType userType = mapper.map(userService.updateUser(mapper.map(user, User.class)), UserType.class);
+        userType.setRoles(user.getRoles());
+        userType.setPreferences(user.getPreferences());
+        userType.setPhotoURL(user.getPhotoURL());
+        return userType;
+    }
 
-	@ResponseStatusDetails
-	@ApiOperation(value = "Update user password", nickname = "updateUserPassword", httpMethod = "PUT")
-	@ResponseStatus(HttpStatus.OK)
-	@ApiImplicitParams(
-	{ @ApiImplicitParam(name = "Authorization", paramType = "header") })
-	@RequestMapping(value = "password", method = RequestMethod.PUT)
-	public void updateUserPassword(@Valid @RequestBody PasswordChangingType password) throws ServiceException
-	{
-		checkCurrentUserAccess(password.getUserId());
-		userService.updateUserPassword(password, isAdmin() && password.getOldPassword() == null);
-	}
+    @ResponseStatusDetails
+    @ApiOperation(value = "Delete user profile photo", nickname = "deleteUserProfilePhoto", httpMethod = "DELETE")
+    @ApiImplicitParams({@ApiImplicitParam(name = "Authorization", paramType = "header")})
+    @DeleteMapping("/profile/photo")
+    public void deleteUserProfilePhoto() throws ServiceException {
+        User user = userService.getUserById(getPrincipalId());
+        amazonService.removeFile(user.getPhotoURL());
+        user.setPhotoURL(StringUtils.EMPTY);
+        userService.updateUser(user);
+    }
 
-	@ResponseStatusDetails
-	@ApiOperation(value = "Search users", nickname = "searchUsers", httpMethod = "POST", response = SearchResult.class)
-	@ResponseStatus(HttpStatus.OK)
-	@ApiImplicitParams(
-	{ @ApiImplicitParam(name = "Authorization", paramType = "header") })
-	@PreAuthorize("#isPublic or (hasRole('ROLE_ADMIN') and hasAnyPermission('VIEW_USERS', 'MODIFY_USERS'))")
-	@RequestMapping(value = "search", method = RequestMethod.POST, produces = MediaType.APPLICATION_JSON_VALUE)
-	public @ResponseBody SearchResult<User> searchUsers(@Valid @RequestBody UserSearchCriteria sc,
-														@RequestParam(value = "public", required = false) boolean isPublic)
-			throws ServiceException
-	{
-		return userService.searchUsers(sc, isPublic);
-	}
+    @ResponseStatusDetails
+    @ApiOperation(value = "Update user password", nickname = "updateUserPassword", httpMethod = "PUT")
+    @ApiImplicitParams({@ApiImplicitParam(name = "Authorization", paramType = "header")})
+    @PutMapping("/password")
+    public void updateUserPassword(@Valid @RequestBody PasswordChangingType password) throws ServiceException {
+        checkCurrentUserAccess(password.getUserId());
+        userService.updateUserPassword(password, isAdmin() && password.getOldPassword() == null);
+    }
 
-	@ResponseStatusDetails
-	@ApiOperation(value = "Create ot update user", nickname = "createOrUpdateUser", httpMethod = "PUT", response = UserType.class)
-	@ResponseStatus(HttpStatus.OK)
-	@ApiImplicitParams(
-	{ @ApiImplicitParam(name = "Authorization", paramType = "header") })
-	@PreAuthorize("hasRole('ROLE_ADMIN') and hasPermission('MODIFY_USERS')")
-	@RequestMapping(method = RequestMethod.PUT, produces = MediaType.APPLICATION_JSON_VALUE)
-	public @ResponseBody UserType createOrUpdateUser(@RequestBody @Valid UserType user) throws ServiceException
-	{
-		return mapper.map(userService.createOrUpdateUser(mapper.map(user, User.class)), UserType.class);
-	}
+    @ResponseStatusDetails
+    @ApiOperation(value = "Search users", nickname = "searchUsers", httpMethod = "POST", response = SearchResult.class)
+    @ApiImplicitParams({@ApiImplicitParam(name = "Authorization", paramType = "header")})
+    @PreAuthorize("#isPublic or (hasRole('ROLE_ADMIN') and hasAnyPermission('VIEW_USERS', 'MODIFY_USERS'))")
+    @PostMapping("/search")
+    public SearchResult<User> searchUsers(
+            @Valid @RequestBody UserSearchCriteria searchCriteria,
+            @RequestParam(value = "public", required = false) boolean isPublic
+    ) throws ServiceException {
+        return userService.searchUsers(searchCriteria, isPublic);
+    }
 
-	@ResponseStatusDetails
-	@ApiOperation(value = "Update user status", nickname = "updateStatus", httpMethod = "PUT", response = UserType.class)
-	@ResponseStatus(HttpStatus.OK)
-	@ApiImplicitParams(
-			{ @ApiImplicitParam(name = "Authorization", paramType = "header") })
-	@PreAuthorize("hasRole('ROLE_ADMIN') and hasPermission('MODIFY_USERS')")
-	@RequestMapping(value = "status", method = RequestMethod.PUT, produces = MediaType.APPLICATION_JSON_VALUE)
-	public @ResponseBody UserType updateStatus(@RequestBody @Valid UserType user) throws ServiceException
-	{
-		return mapper.map(userService.updateStatus(mapper.map(user, User.class)), UserType.class);
-	}
+    @ResponseStatusDetails
+    @ApiOperation(value = "Create ot update user", nickname = "createOrUpdateUser", httpMethod = "PUT", response = UserType.class)
+    @ApiImplicitParams({@ApiImplicitParam(name = "Authorization", paramType = "header")})
+    @PreAuthorize("hasRole('ROLE_ADMIN') and hasPermission('MODIFY_USERS')")
+    @PutMapping()
+    public UserType createOrUpdateUser(@RequestBody @Valid UserType user) throws ServiceException {
+        return mapper.map(userService.createOrUpdateUser(mapper.map(user, User.class)), UserType.class);
+    }
 
-	@ResponseStatusDetails
-	@ResponseStatus(HttpStatus.OK)
-	@ApiImplicitParams(
-	{ @ApiImplicitParam(name = "Authorization", paramType = "header") })
-	@ApiOperation(value = "Add user to group", nickname = "addUserToGroup", httpMethod = "PUT", response = User.class)
-	@PreAuthorize("hasRole('ROLE_ADMIN') and hasPermission('MODIFY_USER_GROUPS')")
-	@RequestMapping(value = "group/{id}", method = RequestMethod.PUT, produces = MediaType.APPLICATION_JSON_VALUE)
-	public @ResponseBody User addUserToGroup(@RequestBody User user, @PathVariable(value = "id") long id)
-			throws ServiceException
-	{
-		return userService.addUserToGroup(user, id);
-	}
+    @ResponseStatusDetails
+    @ApiOperation(value = "Update user status", nickname = "updateStatus", httpMethod = "PUT", response = UserType.class)
+    @ApiImplicitParams({@ApiImplicitParam(name = "Authorization", paramType = "header")})
+    @PreAuthorize("hasRole('ROLE_ADMIN') and hasPermission('MODIFY_USERS')")
+    @PutMapping("/status")
+    public UserType updateStatus(@RequestBody @Valid UserType user) throws ServiceException {
+        return mapper.map(userService.updateStatus(mapper.map(user, User.class)), UserType.class);
+    }
 
-	@ResponseStatusDetails
-	@ResponseStatus(HttpStatus.OK)
-	@ApiImplicitParams(
-	{ @ApiImplicitParam(name = "Authorization", paramType = "header") })
-	@ApiOperation(value = "Delete user from group", nickname = "deleteUserFromGroup", httpMethod = "DELETE")
-	@PreAuthorize("hasRole('ROLE_ADMIN') and hasPermission('MODIFY_USER_GROUPS')")
-	@RequestMapping(value = "{userId}/group/{groupId}", method = RequestMethod.DELETE)
-	public void deleteUserFromGroup(@PathVariable(value = "groupId") long groupId,
-			@PathVariable(value = "userId") long userId) throws ServiceException
-	{
-		userService.deleteUserFromGroup(groupId, userId);
-	}
+    @ResponseStatusDetails
+    @ApiImplicitParams({@ApiImplicitParam(name = "Authorization", paramType = "header")})
+    @ApiOperation(value = "Add user to group", nickname = "addUserToGroup", httpMethod = "PUT", response = User.class)
+    @PreAuthorize("hasRole('ROLE_ADMIN') and hasPermission('MODIFY_USER_GROUPS')")
+    @PutMapping("/group/{id}")
+    public User addUserToGroup(@RequestBody User user, @PathVariable("id") long id) throws ServiceException {
+        return userService.addUserToGroup(user, id);
+    }
 
-	@ResponseStatusDetails
-	@ResponseStatus(HttpStatus.OK)
-	@ApiImplicitParams(
-			{ @ApiImplicitParam(name = "Authorization", paramType = "header") })
-	@ApiOperation(value = "Get default user preferences", nickname = "getDefaultUserPreferences", httpMethod = "GET", response = List.class)
-	@RequestMapping(value = "preferences", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-	public @ResponseBody List<UserPreference> getDefaultUserPreferences() throws ServiceException
-	{
-		return userPreferenceService.getAllUserPreferences(userService.getUserByUsername("anonymous").getId());
-	}
+    @ResponseStatusDetails
+    @ApiImplicitParams({@ApiImplicitParam(name = "Authorization", paramType = "header")})
+    @ApiOperation(value = "Delete user from group", nickname = "deleteUserFromGroup", httpMethod = "DELETE")
+    @PreAuthorize("hasRole('ROLE_ADMIN') and hasPermission('MODIFY_USER_GROUPS')")
+    @DeleteMapping("/{userId}/group/{groupId}")
+    public void deleteUserFromGroup(@PathVariable("groupId") long groupId, @PathVariable("userId") long userId)
+            throws ServiceException {
+        userService.deleteUserFromGroup(groupId, userId);
+    }
+
+    @ResponseStatusDetails
+    @ApiImplicitParams({@ApiImplicitParam(name = "Authorization", paramType = "header")})
+    @ApiOperation(value = "Get default user preferences", nickname = "getDefaultUserPreferences", httpMethod = "GET", response = List.class)
+    @GetMapping("/preferences")
+    public List<UserPreference> getDefaultUserPreferences() throws ServiceException {
+        return userPreferenceService.getAllUserPreferences(userService.getUserByUsername("anonymous").getId());
+    }
 
     @ResponseStatusDetails
     @ApiOperation(value = "Update user preferences", nickname = "createDashboardAttribute", httpMethod = "PUT", response = List.class)
-    @ResponseStatus(HttpStatus.OK) @ApiImplicitParams({ @ApiImplicitParam(name = "Authorization", paramType = "header") })
-    @RequestMapping(value="{userId}/preferences", method = RequestMethod.PUT, produces = MediaType.APPLICATION_JSON_VALUE)
-    public @ResponseBody List<UserPreference> createUserPreference(@PathVariable(value="userId") long userId, @RequestBody List<UserPreference> preferences) throws ServiceException {
-
-	    for (UserPreference preference: preferences){
+    @ApiImplicitParams({@ApiImplicitParam(name = "Authorization", paramType = "header")})
+    @RequestMapping(value = "{userId}/preferences", method = RequestMethod.PUT)
+    public List<UserPreference> createUserPreference(
+            @PathVariable("userId") long userId,
+            @RequestBody List<UserPreference> preferences
+    ) throws ServiceException {
+        for (UserPreference preference : preferences) {
             userPreferenceService.createOrUpdateUserPreference(preference);
         }
         return userPreferenceService.getAllUserPreferences(userId);
     }
 
-	@ResponseStatusDetails
+    @ResponseStatusDetails
     @ApiOperation(value = "Reset user preferences to default", nickname = "resetUserPreferencesToDefault", httpMethod = "PUT", response = List.class)
-    @ResponseStatus(HttpStatus.OK) @ApiImplicitParams({
-   				@ApiImplicitParam(name = "Authorization", paramType = "header") })
-    @RequestMapping(value = "preferences/default", method = RequestMethod.PUT, produces = MediaType.APPLICATION_JSON_VALUE)
-    public @ResponseBody List<UserPreference> resetUserPreferencesToDefault() throws ServiceException
-    {
-   		return userPreferenceService.resetUserPreferencesToDefault(getPrincipalId());
-   	}
+    @ApiImplicitParams({@ApiImplicitParam(name = "Authorization", paramType = "header")})
+    @PutMapping("/preferences/default")
+    public List<UserPreference> resetUserPreferencesToDefault() throws ServiceException {
+        return userPreferenceService.resetUserPreferencesToDefault(getPrincipalId());
+    }
 
-	@ResponseStatusDetails
-	@ApiOperation(value = "Delete user preferences", nickname = "deleteUserPreferences", httpMethod = "DELETE")
-	@ResponseStatus(HttpStatus.OK)
-	@ApiImplicitParams(
-			{ @ApiImplicitParam(name = "Authorization", paramType = "header") })
-	@RequestMapping(value = "{userId}/preferences", method = RequestMethod.DELETE)
-	public void deleteUserPreferences(@PathVariable(value = "userId") long userId) throws ServiceException
-	{
+    @ResponseStatusDetails
+    @ApiOperation(value = "Delete user preferences", nickname = "deleteUserPreferences", httpMethod = "DELETE")
+    @ApiImplicitParams({@ApiImplicitParam(name = "Authorization", paramType = "header")})
+    @DeleteMapping("/{userId}/preferences")
+    public void deleteUserPreferences(@PathVariable("userId") long userId) throws ServiceException {
         userPreferenceService.deleteUserPreferencesByUserId(userId);
-	}
+    }
+
 }

--- a/sources/zafira-ws/src/main/java/com/qaprosoft/zafira/ws/controller/application/ViewsAPIController.java
+++ b/sources/zafira-ws/src/main/java/com/qaprosoft/zafira/ws/controller/application/ViewsAPIController.java
@@ -15,108 +15,89 @@
  *******************************************************************************/
 package com.qaprosoft.zafira.ws.controller.application;
 
-import java.util.List;
-
-import javax.validation.Valid;
-
-import com.qaprosoft.zafira.ws.controller.AbstractController;
-import org.dozer.Mapper;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
-import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.CrossOrigin;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.ResponseBody;
-import org.springframework.web.bind.annotation.ResponseStatus;
-
 import com.qaprosoft.zafira.models.db.View;
 import com.qaprosoft.zafira.models.dto.ViewType;
 import com.qaprosoft.zafira.services.exceptions.ServiceException;
 import com.qaprosoft.zafira.services.services.application.ViewService;
+import com.qaprosoft.zafira.ws.controller.AbstractController;
 import com.qaprosoft.zafira.ws.swagger.annotations.ResponseStatusDetails;
-
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiImplicitParam;
 import io.swagger.annotations.ApiImplicitParams;
 import io.swagger.annotations.ApiOperation;
+import org.dozer.Mapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
-@Controller
-@Api(value = "Views API")
+import javax.validation.Valid;
+import java.util.List;
+
+@Api("Views API")
 @CrossOrigin
-@RequestMapping("api/views")
-public class ViewsAPIController extends AbstractController
-{
+@RequestMapping(path = "api/views", produces = MediaType.APPLICATION_JSON_VALUE)
+@RestController
+public class ViewsAPIController extends AbstractController {
 
-	@Autowired
-	private Mapper mapper;
+    @Autowired
+    private Mapper mapper;
 
-	@Autowired
-	private ViewService viewService;
+    @Autowired
+    private ViewService viewService;
 
-	@ResponseStatusDetails
-	@ApiOperation(value = "Get view", nickname = "getViewById", httpMethod = "GET", response = View.class)
-	@ResponseStatus(HttpStatus.OK)
-	@ApiImplicitParams(
-	{ @ApiImplicitParam(name = "Authorization", paramType = "header") })
-	@PreAuthorize("hasAnyPermission('VIEW_TEST_RUN_VIEWS', 'MODIFY_TEST_RUN_VIEWS')")
-	@RequestMapping(value = "{id}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-	public @ResponseBody View getViewById(@PathVariable(value = "id") long id) throws ServiceException
-	{
-		return viewService.getViewById(id);
-	}
+    @ResponseStatusDetails
+    @ApiOperation(value = "Get view", nickname = "getViewById", httpMethod = "GET", response = View.class)
+    @ApiImplicitParams({@ApiImplicitParam(name = "Authorization", paramType = "header")})
+    @PreAuthorize("hasAnyPermission('VIEW_TEST_RUN_VIEWS', 'MODIFY_TEST_RUN_VIEWS')")
+    @GetMapping("/{id}")
+    public View getViewById(@PathVariable("id") long id) throws ServiceException {
+        return viewService.getViewById(id);
+    }
 
-	@ResponseStatusDetails
-	@ApiOperation(value = "Get all views", nickname = "getAllViews", httpMethod = "GET", response = List.class)
-	@ResponseStatus(HttpStatus.OK)
-	@ApiImplicitParams(
-	{ @ApiImplicitParam(name = "Authorization", paramType = "header") })
-	@PreAuthorize("hasAnyPermission('VIEW_TEST_RUN_VIEWS', 'MODIFY_TEST_RUN_VIEWS')")
-	@RequestMapping(method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-	public @ResponseBody List<View> getAllViews(@RequestParam(value = "projectId", required = false) Long projectId)
-			throws ServiceException
-	{
-		return viewService.getAllViews(projectId);
-	}
+    @ResponseStatusDetails
+    @ApiOperation(value = "Get all views", nickname = "getAllViews", httpMethod = "GET", response = List.class)
+    @ApiImplicitParams({@ApiImplicitParam(name = "Authorization", paramType = "header")})
+    @PreAuthorize("hasAnyPermission('VIEW_TEST_RUN_VIEWS', 'MODIFY_TEST_RUN_VIEWS')")
+    @GetMapping()
+    public List<View> getAllViews(@RequestParam(value = "projectId", required = false) Long projectId) throws ServiceException {
+        return viewService.getAllViews(projectId);
+    }
 
-	@ResponseStatusDetails
-	@ApiOperation(value = "Create view", nickname = "createView", httpMethod = "POST", response = ViewType.class)
-	@ResponseStatus(HttpStatus.OK)
-	@ApiImplicitParams(
-	{ @ApiImplicitParam(name = "Authorization", paramType = "header") })
-	@PreAuthorize("hasPermission('MODIFY_TEST_RUN_VIEWS')")
-	@RequestMapping(method = RequestMethod.POST, produces = MediaType.APPLICATION_JSON_VALUE)
-	public @ResponseBody ViewType createView(@RequestBody @Valid ViewType view) throws ServiceException
-	{
-		return mapper.map(viewService.createView(mapper.map(view, View.class)), ViewType.class);
-	}
+    @ResponseStatusDetails
+    @ApiOperation(value = "Create view", nickname = "createView", httpMethod = "POST", response = ViewType.class)
+    @ApiImplicitParams({@ApiImplicitParam(name = "Authorization", paramType = "header")})
+    @PreAuthorize("hasPermission('MODIFY_TEST_RUN_VIEWS')")
+    @PostMapping()
+    public ViewType createView(@RequestBody @Valid ViewType view) throws ServiceException {
+        return mapper.map(viewService.createView(mapper.map(view, View.class)), ViewType.class);
+    }
 
-	@ResponseStatusDetails
-	@ApiOperation(value = "Update view", nickname = "updateView", httpMethod = "PUT", response = ViewType.class)
-	@ResponseStatus(HttpStatus.OK)
-	@ApiImplicitParams(
-	{ @ApiImplicitParam(name = "Authorization", paramType = "header") })
-	@PreAuthorize("hasPermission('MODIFY_TEST_RUN_VIEWS')")
-	@RequestMapping(method = RequestMethod.PUT, produces = MediaType.APPLICATION_JSON_VALUE)
-	public @ResponseBody ViewType updateView(@RequestBody @Valid ViewType view) throws ServiceException
-	{
-		return mapper.map(viewService.updateView(mapper.map(view, View.class)), ViewType.class);
-	}
+    @ResponseStatusDetails
+    @ApiOperation(value = "Update view", nickname = "updateView", httpMethod = "PUT", response = ViewType.class)
+    @ApiImplicitParams({@ApiImplicitParam(name = "Authorization", paramType = "header")})
+    @PreAuthorize("hasPermission('MODIFY_TEST_RUN_VIEWS')")
+    @PutMapping()
+    public ViewType updateView(@RequestBody @Valid ViewType view) throws ServiceException {
+        return mapper.map(viewService.updateView(mapper.map(view, View.class)), ViewType.class);
+    }
 
-	@ResponseStatusDetails
-	@ApiOperation(value = "Delete view", nickname = "deleteViewById", httpMethod = "DELETE")
-	@ResponseStatus(HttpStatus.OK)
-	@ApiImplicitParams(
-	{ @ApiImplicitParam(name = "Authorization", paramType = "header") })
-	@PreAuthorize("hasPermission('MODIFY_TEST_RUN_VIEWS')")
-	@RequestMapping(value = "{id}", method = RequestMethod.DELETE)
-	public void deleteView(@PathVariable(value = "id") long id) throws ServiceException
-	{
-		viewService.deleteViewById(id);
-	}
+    @ResponseStatusDetails
+    @ApiOperation(value = "Delete view", nickname = "deleteViewById", httpMethod = "DELETE")
+    @ApiImplicitParams({@ApiImplicitParam(name = "Authorization", paramType = "header")})
+    @PreAuthorize("hasPermission('MODIFY_TEST_RUN_VIEWS')")
+    @DeleteMapping("/{id}")
+    public void deleteView(@PathVariable("id") long id) throws ServiceException {
+        viewService.deleteViewById(id);
+    }
+
 }

--- a/sources/zafira-ws/src/main/java/com/qaprosoft/zafira/ws/controller/application/WidgetsAPIController.java
+++ b/sources/zafira-ws/src/main/java/com/qaprosoft/zafira/ws/controller/application/WidgetsAPIController.java
@@ -15,276 +15,253 @@
  *******************************************************************************/
 package com.qaprosoft.zafira.ws.controller.application;
 
+import com.qaprosoft.zafira.dbaccess.utils.SQLAdapter;
+import com.qaprosoft.zafira.models.db.Attribute;
+import com.qaprosoft.zafira.models.db.Widget;
+import com.qaprosoft.zafira.models.db.WidgetTemplate;
+import com.qaprosoft.zafira.models.dto.SQLExecuteType;
+import com.qaprosoft.zafira.models.dto.widget.WidgetTemplateType;
+import com.qaprosoft.zafira.models.dto.widget.WidgetType;
+import com.qaprosoft.zafira.services.exceptions.ServiceException;
+import com.qaprosoft.zafira.services.services.application.SettingsService;
+import com.qaprosoft.zafira.services.services.application.WidgetService;
+import com.qaprosoft.zafira.services.services.application.WidgetTemplateService;
+import com.qaprosoft.zafira.services.util.URLResolver;
+import com.qaprosoft.zafira.ws.controller.AbstractController;
+import com.qaprosoft.zafira.ws.swagger.annotations.ResponseStatusDetails;
+import io.swagger.annotations.ApiImplicitParam;
+import io.swagger.annotations.ApiImplicitParams;
+import io.swagger.annotations.ApiOperation;
+import org.apache.commons.lang.exception.ExceptionUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.dozer.Mapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.util.CollectionUtils;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import springfox.documentation.annotations.ApiIgnore;
+
+import javax.validation.Valid;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import javax.validation.Valid;
-
-import com.qaprosoft.zafira.models.db.WidgetTemplate;
-import com.qaprosoft.zafira.models.dto.SQLExecuteType;
-import com.qaprosoft.zafira.models.dto.widget.WidgetTemplateType;
-import com.qaprosoft.zafira.models.dto.widget.WidgetType;
-import com.qaprosoft.zafira.services.services.application.WidgetTemplateService;
-import org.apache.commons.lang.exception.ExceptionUtils;
-import org.apache.commons.lang3.StringUtils;
-import org.dozer.Mapper;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
-import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.stereotype.Controller;
-import org.springframework.util.CollectionUtils;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.ResponseBody;
-import org.springframework.web.bind.annotation.ResponseStatus;
-
-import com.qaprosoft.zafira.dbaccess.utils.SQLAdapter;
-import com.qaprosoft.zafira.models.db.Attribute;
-import com.qaprosoft.zafira.models.db.Widget;
-import com.qaprosoft.zafira.services.exceptions.ServiceException;
-import com.qaprosoft.zafira.services.services.application.SettingsService;
-import com.qaprosoft.zafira.services.services.application.WidgetService;
-import com.qaprosoft.zafira.services.util.URLResolver;
-import com.qaprosoft.zafira.ws.controller.AbstractController;
-import com.qaprosoft.zafira.ws.swagger.annotations.ResponseStatusDetails;
-
-import io.swagger.annotations.ApiImplicitParam;
-import io.swagger.annotations.ApiImplicitParams;
-import io.swagger.annotations.ApiOperation;
-import springfox.documentation.annotations.ApiIgnore;
-
-@Controller
 @ApiIgnore
-@RequestMapping("api/widgets")
-public class WidgetsAPIController extends AbstractController
-{
-	@Autowired
-	private URLResolver urlResolver;
+@RequestMapping(path = "api/widgets", produces = MediaType.APPLICATION_JSON_VALUE)
+@RestController
+public class WidgetsAPIController extends AbstractController {
 
-	@Autowired
-	private WidgetService widgetService;
+    @Autowired
+    private URLResolver urlResolver;
 
-	@Autowired
-	private WidgetTemplateService widgetTemplateService;
+    @Autowired
+    private WidgetService widgetService;
 
-	@Autowired
-	private SettingsService settingsService;
+    @Autowired
+    private WidgetTemplateService widgetTemplateService;
 
-	@Autowired
-	private Mapper mapper;
+    @Autowired
+    private SettingsService settingsService;
 
-	@ResponseStatusDetails
-	@ApiOperation(value = "Create widget", nickname = "createWidget", httpMethod = "POST", response = Widget.class)
-	@ResponseStatus(HttpStatus.OK)
-	@ApiImplicitParams(
-	{ @ApiImplicitParam(name = "Authorization", paramType = "header") })
-	@PreAuthorize("hasPermission('MODIFY_WIDGETS')")
-	@RequestMapping(method = RequestMethod.POST, produces = MediaType.APPLICATION_JSON_VALUE)
-	public @ResponseBody WidgetType createWidget(@RequestBody @Valid WidgetType widget,
-			@RequestHeader(value = "Project", required = false) String project) throws ServiceException
-	{
-		if(widget.getWidgetTemplate() != null) {
-			WidgetTemplate widgetTemplate = widgetTemplateService.getWidgetTemplateById(widget.getWidgetTemplate().getId());
-			if(widgetTemplate == null) {
-				throw new ServiceException("Unable to create chart. Template with id " + widget.getWidgetTemplate().getId() + " does not exist.");
-			}
-			widgetTemplateService.clearRedundantParamsValues(widgetTemplate);
-			//widgetTemplateService.executeWidgetTemplateParamsSQLQueries(widgetTemplate);
-			widget.setWidgetTemplate(mapper.map(widgetTemplate, WidgetTemplateType.class));
-			widget.setType(widgetTemplate.getType().name());
-		}
-		return mapper.map(widgetService.createWidget(mapper.map(widget, Widget.class)), WidgetType.class);
-	}
+    @Autowired
+    private Mapper mapper;
 
-	@ResponseStatusDetails
-	@ApiOperation(value = "Get widget", nickname = "getWidget", httpMethod = "GET", response = Widget.class)
-	@ResponseStatus(HttpStatus.OK)
-	@ApiImplicitParams(
-	{ @ApiImplicitParam(name = "Authorization", paramType = "header") })
-	@RequestMapping(value = "{id}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-	public @ResponseBody Widget getWidget(@PathVariable(value = "id") long id) throws ServiceException
-	{
-		return widgetService.getWidgetById(id);
-	}
-
-	@ResponseStatusDetails
-	@ApiOperation(value = "Delete widget", nickname = "deleteWidget", httpMethod = "DELETE")
-	@ResponseStatus(HttpStatus.OK)
-	@ApiImplicitParams(
-	{ @ApiImplicitParam(name = "Authorization", paramType = "header") })
-	@PreAuthorize("hasPermission('MODIFY_WIDGETS')")
-	@RequestMapping(value = "{id}", method = RequestMethod.DELETE)
-	public void deleteWidget(@PathVariable(value = "id") long id) throws ServiceException
-	{
-		widgetService.deleteWidgetById(id);
-	}
-
-	@ResponseStatusDetails
-	@ApiOperation(value = "Update widget", nickname = "updateWidget", httpMethod = "PUT", response = Widget.class)
-	@ResponseStatus(HttpStatus.OK)
-	@ApiImplicitParams(
-	{ @ApiImplicitParam(name = "Authorization", paramType = "header") })
-	@PreAuthorize("hasPermission('MODIFY_WIDGETS')")
-	@RequestMapping(method = RequestMethod.PUT, produces = MediaType.APPLICATION_JSON_VALUE)
-	public @ResponseBody Widget updateWidget(@RequestBody WidgetType widget) throws ServiceException
-	{
-		if(widget.getWidgetTemplate() != null) {
-			WidgetTemplate widgetTemplate = widgetTemplateService.getWidgetTemplateById(widget.getWidgetTemplate().getId());
-			if(widgetTemplate == null) {
-				throw new ServiceException("Unable to update widget. Widget template does not exist");
-			}
-			widgetTemplateService.clearRedundantParamsValues(widgetTemplate);
-			//widgetTemplateService.executeWidgetTemplateParamsSQLQueries(widgetTemplate);
-			widget.setWidgetTemplate(mapper.map(widgetTemplate, WidgetTemplateType.class));
-		}
-		return widgetService.updateWidget(mapper.map(widget, Widget.class));
-	}
-
-	@ResponseStatusDetails
-	@ApiOperation(value = "Execute SQL", nickname = "executeSQL", httpMethod = "POST", response = List.class)
-	@ResponseStatus(HttpStatus.OK)
-	@ApiImplicitParams(
-	{ @ApiImplicitParam(name = "Authorization", paramType = "header") })
-	@RequestMapping(value = "sql", method = RequestMethod.POST, produces = MediaType.APPLICATION_JSON_VALUE)
-	public @ResponseBody List<Map<String, Object>> executeSQL(@RequestBody @Valid SQLAdapter sql,
-			@RequestParam(value = "projects", defaultValue = "", required = false) List<String> projects,
-			@RequestParam(value = "currentUserId", required = false) String currentUserId,
-			@RequestParam(value = "dashboardName", required = false) String dashboardName,
-            @RequestParam(value = "stackTraceRequired", required = false) boolean stackTraceRequired ) throws ServiceException
-	{
-		String query = sql.getSql();
-		List<Map<String, Object>> resultList = null;
-		try {
-			if(query != null) {
-				if (sql.getAttributes() != null) {
-					for (Attribute attribute : sql.getAttributes()) {
-						query = query.replaceAll("#\\{" + attribute.getKey() + "\\}", attribute.getValue());
-					}
-				}
-
-				query = query
-						.replaceAll("#\\{project}", formatProjects(projects))
-						.replaceAll("#\\{dashboardName}", !StringUtils.isEmpty(dashboardName) ? dashboardName : "")
-						.replaceAll("#\\{currentUserId}", !StringUtils.isEmpty(currentUserId) ? currentUserId : String.valueOf(getPrincipalId()))
-						.replaceAll("#\\{currentUserName}", String.valueOf(getPrincipalName()))
-						.replaceAll("#\\{zafiraURL}", urlResolver.buildWebURL())
-						.replaceAll("#\\{jenkinsURL}", settingsService.getSettingByName("JENKINS_URL").getValue())
-						.replaceAll("#\\{hashcode}", "0")
-						.replaceAll("#\\{testCaseId}", "0");
-
-				resultList = widgetService.executeSQL(query);
-			}
+    @ResponseStatusDetails
+    @ApiOperation(value = "Create widget", nickname = "createWidget", httpMethod = "POST", response = Widget.class)
+    @ApiImplicitParams({@ApiImplicitParam(name = "Authorization", paramType = "header")})
+    @PreAuthorize("hasPermission('MODIFY_WIDGETS')")
+    @PostMapping()
+    public WidgetType createWidget(
+            @RequestBody @Valid WidgetType widget,
+            @RequestHeader(value = "Project", required = false) String project
+    ) throws ServiceException {
+        if (widget.getWidgetTemplate() != null) {
+            WidgetTemplate widgetTemplate = widgetTemplateService.getWidgetTemplateById(widget.getWidgetTemplate().getId());
+            if (widgetTemplate == null) {
+                throw new ServiceException("Unable to create chart. Template with id " + widget.getWidgetTemplate().getId() + " does not exist.");
+            }
+            widgetTemplateService.clearRedundantParamsValues(widgetTemplate);
+            widget.setWidgetTemplate(mapper.map(widgetTemplate, WidgetTemplateType.class));
+            widget.setType(widgetTemplate.getType().name());
         }
-        catch (Exception e) {
+        return mapper.map(widgetService.createWidget(mapper.map(widget, Widget.class)), WidgetType.class);
+    }
+
+    @ResponseStatusDetails
+    @ApiOperation(value = "Get widget", nickname = "getWidget", httpMethod = "GET", response = Widget.class)
+    @ApiImplicitParams({@ApiImplicitParam(name = "Authorization", paramType = "header")})
+    @GetMapping("/{id}")
+    public Widget getWidget(@PathVariable("id") long id) throws ServiceException {
+        return widgetService.getWidgetById(id);
+    }
+
+    @ResponseStatusDetails
+    @ApiOperation(value = "Delete widget", nickname = "deleteWidget", httpMethod = "DELETE")
+    @ApiImplicitParams({@ApiImplicitParam(name = "Authorization", paramType = "header")})
+    @PreAuthorize("hasPermission('MODIFY_WIDGETS')")
+    @DeleteMapping("/{id}")
+    public void deleteWidget(@PathVariable("id") long id) throws ServiceException {
+        widgetService.deleteWidgetById(id);
+    }
+
+    @ResponseStatusDetails
+    @ApiOperation(value = "Update widget", nickname = "updateWidget", httpMethod = "PUT", response = Widget.class)
+    @ApiImplicitParams({@ApiImplicitParam(name = "Authorization", paramType = "header")})
+    @PreAuthorize("hasPermission('MODIFY_WIDGETS')")
+    @PutMapping()
+    public Widget updateWidget(@RequestBody WidgetType widget) throws ServiceException {
+        if (widget.getWidgetTemplate() != null) {
+            WidgetTemplate widgetTemplate = widgetTemplateService
+                    .getWidgetTemplateById(widget.getWidgetTemplate().getId());
+            if (widgetTemplate == null) {
+                throw new ServiceException("Unable to update widget. Widget template does not exist");
+            }
+            widgetTemplateService.clearRedundantParamsValues(widgetTemplate);
+            //widgetTemplateService.executeWidgetTemplateParamsSQLQueries(widgetTemplate);
+            widget.setWidgetTemplate(mapper.map(widgetTemplate, WidgetTemplateType.class));
+        }
+        return widgetService.updateWidget(mapper.map(widget, Widget.class));
+    }
+
+    @ResponseStatusDetails
+    @ApiOperation(value = "Execute SQL", nickname = "executeSQL", httpMethod = "POST", response = List.class)
+    @ApiImplicitParams({@ApiImplicitParam(name = "Authorization", paramType = "header")})
+    @PostMapping("/sql")
+    public List<Map<String, Object>> executeSQL(
+            @RequestBody @Valid SQLAdapter sql,
+            @RequestParam(value = "projects", defaultValue = "", required = false) List<String> projects,
+            @RequestParam(value = "currentUserId", required = false) String currentUserId,
+            @RequestParam(value = "dashboardName", required = false) String dashboardName,
+            @RequestParam(value = "stackTraceRequired", required = false) boolean stackTraceRequired
+    ) throws ServiceException {
+        String query = sql.getSql();
+        List<Map<String, Object>> resultList = null;
+        try {
+            if (query != null) {
+                if (sql.getAttributes() != null) {
+                    for (Attribute attribute : sql.getAttributes()) {
+                        query = query.replaceAll("#\\{" + attribute.getKey() + "\\}", attribute.getValue());
+                    }
+                }
+
+                query = query
+                        .replaceAll("#\\{project}", formatProjects(projects))
+                        .replaceAll("#\\{dashboardName}", !StringUtils.isEmpty(dashboardName) ? dashboardName : "")
+                        .replaceAll("#\\{currentUserId}", !StringUtils.isEmpty(currentUserId) ? currentUserId : String
+                                .valueOf(getPrincipalId()))
+                        .replaceAll("#\\{currentUserName}", String.valueOf(getPrincipalName()))
+                        .replaceAll("#\\{zafiraURL}", urlResolver.buildWebURL())
+                        .replaceAll("#\\{jenkinsURL}", settingsService.getSettingByName("JENKINS_URL").getValue())
+                        .replaceAll("#\\{hashcode}", "0")
+                        .replaceAll("#\\{testCaseId}", "0");
+
+                resultList = widgetService.executeSQL(query);
+            }
+        } catch (Exception e) {
             if (stackTraceRequired) {
                 resultList = new ArrayList<>();
                 Map<String, Object> exceptionMap = new HashMap<>();
                 exceptionMap.put("Check your query", ExceptionUtils.getFullStackTrace(e));
                 resultList.add(exceptionMap);
                 return resultList;
-            }
-            else {
+            } else {
                 throw e;
             }
         }
         return resultList;
     }
-	
-	private String formatProjects(List<String> projects)
-	{
-		String result = "%";
-		if(!CollectionUtils.isEmpty(projects))
-		{
-			StringBuilder sb = new StringBuilder();
-			for(String project : projects)
-			{
-				sb.append(project).append(",");
-			}
-			result = StringUtils.removeEnd(sb.toString(), ",");
-		}
-		return result;
-	}
 
-	@ResponseStatusDetails
-	@ApiOperation(value = "Get all widgets", nickname = "getAllWidgets", httpMethod = "GET", response = List.class)
-	@ResponseStatus(HttpStatus.OK)
-	@ApiImplicitParams(
-	{ @ApiImplicitParam(name = "Authorization", paramType = "header") })
-	@RequestMapping(method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-	public @ResponseBody List<WidgetType> getAllWidgets() throws ServiceException
-	{
-		return widgetService.getAllWidgets().stream().map(widget -> {
-			widgetTemplateService.clearRedundantParamsValues(widget.getWidgetTemplate());
-		    //widgetTemplateService.executeWidgetTemplateParamsSQLQueries(widget.getWidgetTemplate());
-		    return mapper.map(widget, WidgetType.class);
-        }).collect(Collectors.toList());
-	}
+    private String formatProjects(List<String> projects) {
+        String result = "%";
+        if (!CollectionUtils.isEmpty(projects)) {
+            StringBuilder sb = new StringBuilder();
+            for (String project : projects) {
+                sb.append(project).append(",");
+            }
+            result = StringUtils.removeEnd(sb.toString(), ",");
+        }
+        return result;
+    }
 
-	@ResponseStatusDetails
-	@ApiOperation(value = "Get all widget templates", nickname = "getAllWidgetTemplates", httpMethod = "GET", response = List.class)
-	@ResponseStatus(HttpStatus.OK)
-	@ApiImplicitParams(
-			{ @ApiImplicitParam(name = "Authorization", paramType = "header") })
-	@RequestMapping(value = "templates", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-	public @ResponseBody List<WidgetTemplateType> getAllWidgetTemplates() throws ServiceException
-	{
-		return widgetTemplateService.getWidgetTemplates().stream().map(widgetTemplate -> mapper.map(widgetTemplate, WidgetTemplateType.class)).collect(Collectors.toList());
-	}
+    @ResponseStatusDetails
+    @ApiOperation(value = "Get all widgets", nickname = "getAllWidgets", httpMethod = "GET", response = List.class)
+    @ApiImplicitParams({@ApiImplicitParam(name = "Authorization", paramType = "header")})
+    @GetMapping()
+    public List<WidgetType> getAllWidgets() throws ServiceException {
+        return widgetService.getAllWidgets()
+                            .stream()
+                            .map(widget -> {
+                                widgetTemplateService.clearRedundantParamsValues(widget.getWidgetTemplate());
+                                return mapper.map(widget, WidgetType.class);
+                            }).collect(Collectors.toList());
+    }
 
-	@ResponseStatusDetails
-	@ApiOperation(value = "Prepare widget template data by id", nickname = "prepareWidgetTemplateById", httpMethod = "GET", response = WidgetTemplateType.class)
-	@ResponseStatus(HttpStatus.OK)
-	@ApiImplicitParams(
-			{ @ApiImplicitParam(name = "Authorization", paramType = "header") })
-	@RequestMapping(value = "templates/{id}/prepare", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-	public @ResponseBody WidgetTemplateType prepareWidgetTemplate(@PathVariable(value = "id") Long id) throws ServiceException
-	{
-		return mapper.map(widgetTemplateService.prepareWidgetTemplateById(id), WidgetTemplateType.class);
-	}
+    @ResponseStatusDetails
+    @ApiOperation(value = "Get all widget templates", nickname = "getAllWidgetTemplates", httpMethod = "GET", response = List.class)
+    @ApiImplicitParams({@ApiImplicitParam(name = "Authorization", paramType = "header")})
+    @GetMapping("/templates")
+    public List<WidgetTemplateType> getAllWidgetTemplates() throws ServiceException {
+        return widgetTemplateService.getWidgetTemplates()
+                                    .stream()
+                                    .map(widgetTemplate -> mapper.map(widgetTemplate, WidgetTemplateType.class))
+                                    .collect(Collectors.toList());
+    }
 
-	@ResponseStatusDetails
-	@ApiOperation(value = "Execute SQL template", nickname = "executeSQLTemplate", httpMethod = "POST", response = List.class)
-	@ResponseStatus(HttpStatus.OK)
-	@ApiImplicitParams(
-			{ @ApiImplicitParam(name = "Authorization", paramType = "header") })
-	@RequestMapping(value = "templates/sql", method = RequestMethod.POST, produces = MediaType.APPLICATION_JSON_VALUE)
-	public @ResponseBody List<Map<String, Object>> executeSQLTemplate(@RequestBody @Valid SQLExecuteType sqlExecuteType,
-																	  @RequestParam(value = "stackTraceRequired", required = false) boolean stackTraceRequired) throws ServiceException
-	{
-		WidgetTemplate widgetTemplate = widgetTemplateService.getWidgetTemplateById(sqlExecuteType.getTemplateId());
-		if(widgetTemplate == null) {
-			throw new ServiceException("Unable to execute SQL query.");
-		}
-		List<Map<String, Object>> resultList;
-		try {
-			Map<WidgetService.DefaultParam, Object> additionalParameters = new HashMap<>();
-			additionalParameters.put(WidgetService.DefaultParam.CURRENT_USER_NAME, getPrincipalName());
-			additionalParameters.put(WidgetService.DefaultParam.CURRENT_USER_ID, getPrincipalId());
-			resultList = widgetService.executeSQL(widgetTemplate.getSql(), sqlExecuteType.getParamsConfig(), additionalParameters, true);
-		} catch (Exception e) {
-			if(stackTraceRequired) {
-				resultList = new ArrayList<>();
-				resultList.add(new HashMap<String, Object>() {
-					private static final long serialVersionUID = -6210274356733655725L;
+    @ResponseStatusDetails
+    @ApiOperation(value = "Prepare widget template data by id", nickname = "prepareWidgetTemplateById", httpMethod = "GET", response = WidgetTemplateType.class)
+    @ApiImplicitParams({@ApiImplicitParam(name = "Authorization", paramType = "header")})
+    @GetMapping("/templates/{id}/prepare")
+    public WidgetTemplateType prepareWidgetTemplate(@PathVariable("id") Long id) throws ServiceException {
+        return mapper.map(widgetTemplateService.prepareWidgetTemplateById(id), WidgetTemplateType.class);
+    }
 
-					{
-						put("Check your query", ExceptionUtils.getFullStackTrace(e));
-					}
-				});
-				return resultList;
-			} else {
-				throw new ServiceException(e.getMessage(), e);
-			}
-		}
-		return resultList;
-	}
+    @ResponseStatusDetails
+    @ApiOperation(value = "Execute SQL template", nickname = "executeSQLTemplate", httpMethod = "POST", response = List.class)
+    @ApiImplicitParams({@ApiImplicitParam(name = "Authorization", paramType = "header")})
+    @PostMapping("/templates/sql")
+    public List<Map<String, Object>> executeSQLTemplate(
+            @RequestBody @Valid SQLExecuteType sqlExecuteType,
+            @RequestParam(value = "stackTraceRequired", required = false) boolean stackTraceRequired
+    ) throws ServiceException {
+        WidgetTemplate widgetTemplate = widgetTemplateService.getWidgetTemplateById(sqlExecuteType.getTemplateId());
+        if (widgetTemplate == null) {
+            throw new ServiceException("Unable to execute SQL query.");
+        }
+        List<Map<String, Object>> resultList;
+        try {
+            Map<WidgetService.DefaultParam, Object> additionalParameters = new HashMap<>();
+            additionalParameters.put(WidgetService.DefaultParam.CURRENT_USER_NAME, getPrincipalName());
+            additionalParameters.put(WidgetService.DefaultParam.CURRENT_USER_ID, getPrincipalId());
+            resultList = widgetService
+                    .executeSQL(widgetTemplate.getSql(), sqlExecuteType.getParamsConfig(), additionalParameters, true);
+        } catch (Exception e) {
+            if (stackTraceRequired) {
+                resultList = new ArrayList<>();
+                resultList.add(new HashMap<String, Object>() {
+                    private static final long serialVersionUID = -6210274356733655725L;
+
+                    {
+                        put("Check your query", ExceptionUtils.getFullStackTrace(e));
+                    }
+                });
+                return resultList;
+            } else {
+                throw new ServiceException(e.getMessage(), e);
+            }
+        }
+        return resultList;
+    }
 
 }


### PR DESCRIPTION
Controllers refactored:

- `@Controller` replaced with `@RestController` which omits view resolution and marshals Java objects to response body (making explicit `@ResponseBody` redundant)
- Produced media type declaration moved to class-level vs method level - it is inherited at method level and overrides placed where necessary 
- `@RequestMapping(method=XXX)` replaced with Spring 4.3 shortcut annotations: `@GetMapping`, `@PostMapping`, `@PutMapping`, `@DeleteMapping`, etc
- single `value` attributes for annotations removed: `value` is implicitly set when there're no other attributes specified making explicit declaration redundant
- `@ResponseStatus(HttpStatus.OK)` annotations removed - OK is default response code and thus there's no need to explicitly set it.
- consistent code style applied to all controller source files
- minor logic refactoring performed along the way
- redundant imports removed

Please review carefully. Rollout risk: low.

P.S.: Sorry for many files in single PR - changes are typical and easy to review once you'll understand where to look :)