### PR TITLE
updated git clone URL from SSH to HTTP

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -49,7 +49,7 @@ e8a2d32590ed        qaprosoft/postgres:9.6              "docker-entrypoint.s…"
 
 * Open Zafira in your browser:
 ```
-http://localhost:8080/zafira
+http://localhost:80/app
 ```
 
 * Use default credentials to login:

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -21,7 +21,7 @@ Before running Zafira, verify that following ports are not binded:
 #### Startup in Docker
 * Clone Zafira repo:
 ```
-$ git clone git@github.com:qaprosoft/zafira.git
+$ git clone https://github.com/qaprosoft/zafira.git
 ```
 
 * If you are planning to access Zafira remotely you will need to modify **docker-compose.yml** specifying appropriate IP address of your host:


### PR DESCRIPTION
unable to clone by public account due to incorrect access rights